### PR TITLE
feat: 캘린더 조회

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "harumoa",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.13.4",
+        "@tanstack/react-query-devtools": "^5.13.5",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -15,6 +17,7 @@
         "@types/node": "^16.18.66",
         "@types/react": "^18.2.41",
         "@types/react-dom": "^18.2.17",
+        "dayjs": "^1.11.10",
         "firebase": "^10.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4212,6 +4215,55 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.13.4.tgz",
+      "integrity": "sha512-8+rJucXvC/xlr4OrxHhEIob/cTlbT4fgmz1VsvB0D12FRStKaXeLORNGcOhSAynRd2NL74SV/Qq0IIb4DedLcA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.13.5.tgz",
+      "integrity": "sha512-effSYz9AWcZ6sNd+c8LCBYFIuDZApoCTXEpRlEYChBZpMz9QUUVMLToThwCyUY49+T5pANL3XxgZf3HV7hwJlg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.13.4.tgz",
+      "integrity": "sha512-3HjvkFFriEQwffUXtKHPiwkfFXUGbs46YATTzzyK1+Pw6Ekd3kwzS50e45qdamWuEXmXxyo5S1zp534LdFG0Rw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.13.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.13.5.tgz",
+      "integrity": "sha512-FB17B/yPtwnqg+DAdosAM+rFj3t8Pl121MPLiUGgl6jvG0A+U9XN3n39zVbhurbdSFO5jCMkPBlloW4NH5ojrA==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.13.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.13.4",
+        "react": "^18.0.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
@@ -7128,6 +7180,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@tanstack/react-query": "^5.13.4",
+    "@tanstack/react-query-devtools": "^5.13.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -10,6 +12,7 @@
     "@types/node": "^16.18.66",
     "@types/react": "^18.2.41",
     "@types/react-dom": "^18.2.17",
+    "dayjs": "^1.11.10",
     "firebase": "^10.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,9 @@ import Write from './pages/Write'
 import Detail from './pages/Detail'
 import Root from './pages/Root'
 import NotFound from './pages/NotFound'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { queryClient } from './api/react-query'
 
 const router = createBrowserRouter([
   {
@@ -30,7 +33,11 @@ const router = createBrowserRouter([
 ])
 
 const App = () => {
-  return <RouterProvider router={router} />
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      <ReactQueryDevtools />
+    </QueryClientProvider>
+  )
 }
-
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import NotFound from './pages/NotFound'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { queryClient } from './api/react-query'
+import GlobalStyle from './assets/css/global'
 
 const router = createBrowserRouter([
   {
@@ -36,6 +37,7 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <GlobalStyle />
       <ReactQueryDevtools />
     </QueryClientProvider>
   )

--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app'
-import { getDatabase } from 'firebase/database'
+import { child, get, getDatabase, ref } from 'firebase/database'
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -15,3 +15,20 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig)
 const db = getDatabase(app)
+
+export async function getBooks(year: string, month: string) {
+  const uid = 349392019
+
+  try {
+    const snapshot = await get(child(ref(db), `books/${uid}/${year}/${month}`))
+
+    if (snapshot.exists()) {
+      return snapshot.val()
+    } else {
+      return {}
+    }
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}

--- a/src/api/react-query.ts
+++ b/src/api/react-query.ts
@@ -1,0 +1,17 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export function generateQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 0,
+        gcTime: 300000, // 5 minutes
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+        refetchOnWindowFocus: false,
+      },
+    },
+  })
+}
+
+export const queryClient = generateQueryClient()

--- a/src/assets/css/global.ts
+++ b/src/assets/css/global.ts
@@ -1,0 +1,7 @@
+import { css } from 'styled-components'
+
+export const ellipsisStyles = css`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`

--- a/src/assets/css/global.ts
+++ b/src/assets/css/global.ts
@@ -2,12 +2,6 @@ import { createGlobalStyle } from 'styled-components'
 import { css } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-
   li {
     list-style: none;
   }

--- a/src/assets/css/global.ts
+++ b/src/assets/css/global.ts
@@ -1,4 +1,28 @@
+import { createGlobalStyle } from 'styled-components'
 import { css } from 'styled-components'
+
+const GlobalStyle = createGlobalStyle`
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  li {
+    list-style: none;
+  }
+
+  a {
+    text-decoration: none;
+    color: #000;
+  }
+
+  button {
+    cursor: pointer;
+  }
+`
+
+export default GlobalStyle
 
 export const ellipsisStyles = css`
   text-overflow: ellipsis;

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,0 +1,160 @@
+import dayjs from 'dayjs'
+import { useState } from 'react'
+import styled from 'styled-components'
+import { Books, MonthDetail } from '../types'
+import {
+  getDateArray,
+  getMonthDetails,
+  getMonthYearDetails,
+  getNewMonthYear,
+} from '../utils/calendar'
+import DateBox from './DateBox'
+
+const dayOfTheWeek = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
+const HeaderContainer = styled.header`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+`
+
+const LocationButton = styled.button`
+  width: 30px;
+  height: 30px;
+`
+
+const CalendarContainer = styled.section`
+  padding: 1rem;
+`
+
+const DOWHeader = styled.div`
+  display: flex;
+  margin-bottom: 0.5rem;
+`
+
+const DOWCell = styled.div`
+  flex: 1;
+  text-align: center;
+  padding: '10px';
+  font-weight: 500;
+`
+
+const DateGrid = styled.div<{ $weeksInMonth: number }>`
+  height: calc(100vh - 190px);
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-rows: ${({ $weeksInMonth }) => `repeat(${$weeksInMonth}, 1fr)`};
+  border-bottom: 0.1px solid #ccc;
+  border-left: 0.1px solid #ccc;
+`
+
+const books: Books = {
+  '03': {
+    account_book: {
+      1: {
+        category: '쇼핑',
+        comment: '빵',
+        is_income: false,
+        price: 2000,
+      },
+      2: {
+        category: '쇼핑',
+        comment: '옷',
+        is_income: false,
+        price: 8000,
+      },
+      3: {
+        category: '용돈',
+        comment: '용돈',
+        is_income: true,
+        price: 12000,
+      },
+    },
+    diary: {
+      content: '일기 내용',
+      emotion: '🥲',
+      title: '일기 제목',
+    },
+  },
+  '07': {
+    account_book: {
+      1: {
+        category: '식비',
+        comment: '중식',
+        is_income: false,
+        price: 15000,
+      },
+    },
+    diary: {
+      content: '밥 맛있었음',
+      emotion: '😄',
+      title: '맛집 갔음',
+    },
+  },
+  total: {
+    expense_price: 10000,
+    income_price: 12000,
+  },
+}
+
+const Calendar = () => {
+  const currentMonthYear = getMonthYearDetails(dayjs())
+  const [monthYear, setMonthYear] = useState(currentMonthYear)
+  const prevMonth = getMonthDetails(monthYear.startDate.subtract(1, 'month'))
+
+  function updateMonthYear(monthIncrement: number): void {
+    setMonthYear((prevData) => getNewMonthYear(prevData, monthIncrement))
+  }
+
+  return (
+    <>
+      <HeaderContainer>
+        <LocationButton onClick={() => updateMonthYear(-1)}>
+          {'<'}
+        </LocationButton>
+        <h1>
+          {monthYear.year}년 {monthYear.month}월
+        </h1>
+        <LocationButton onClick={() => updateMonthYear(1)}>
+          {'>'}
+        </LocationButton>
+      </HeaderContainer>
+
+      <CalendarContainer>
+        <DOWHeader>
+          {dayOfTheWeek.map((day, i) => (
+            <DOWCell key={day}>{day}</DOWCell>
+          ))}
+        </DOWHeader>
+
+        <DateGrid $weeksInMonth={monthYear.weeksInMonth}>
+          {/* 캘린더상 전월 날짜 렌더링 */}
+          {getDateArray(monthYear.calendarStartDate, prevMonth.lastDate)?.map(
+            (date, i) => (
+              <DateBox key={date} date={date} />
+            )
+          )}
+
+          {/* 당월 날짜 렌더링 */}
+          {getDateArray(1, monthYear.lastDate)?.map((date, i) => {
+            const detail = books[
+              date.toString().padStart(2, '0')
+            ] as MonthDetail | null
+
+            return (
+              <DateBox key={date} date={date} detail={detail} isCurrentMonth />
+            )
+          })}
+
+          {/* 캘린더상 익월 날짜 렌더링 */}
+          {getDateArray(1, monthYear.calendarLastDate)?.map((date, i) => (
+            <DateBox key={date} date={date} />
+          ))}
+        </DateGrid>
+      </CalendarContainer>
+    </>
+  )
+}
+
+export default Calendar

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -63,10 +63,10 @@ const Calendar = () => {
   })
 
   useEffect(() => {
-    const nextMonthYear = getNewMonthYear(monthYear, 1)
+    const prevMonthYear = getNewMonthYear(monthYear, -1)
     queryClient.prefetchQuery({
-      queryKey: ['books', nextMonthYear.year, nextMonthYear.month],
-      queryFn: () => getBooks(nextMonthYear.year, nextMonthYear.month),
+      queryKey: ['books', prevMonthYear.year, prevMonthYear.month],
+      queryFn: () => getBooks(prevMonthYear.year, prevMonthYear.month),
     })
   }, [queryClient, monthYear])
 

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -105,12 +105,17 @@ const Calendar = () => {
 
           {/* 당월 날짜 렌더링 */}
           {getDateArray(1, monthYear.lastDate)?.map((date, i) => {
-            const detail = query.data?.[
-              date.toString().padStart(2, '0')
-            ] as MonthDetail | null
+            const dateIdx = date.toString().padStart(2, '0')
+            const detail = query.data?.[dateIdx] as MonthDetail | null
+            const selectedDate = `${monthYear.year}-${monthYear.month}-${dateIdx}`
 
             return (
-              <DateBox key={date} date={date} detail={detail} isCurrentMonth />
+              <DateBox
+                selectedDate={selectedDate}
+                date={date}
+                detail={detail}
+                isCurrentMonth
+              />
             )
           })}
 

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -111,6 +111,7 @@ const Calendar = () => {
 
             return (
               <DateBox
+                key={date}
                 selectedDate={selectedDate}
                 date={date}
                 detail={detail}

--- a/src/components/DateBox.tsx
+++ b/src/components/DateBox.tsx
@@ -1,7 +1,7 @@
-import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { ellipsisStyles } from '../assets/css/global'
 import { MonthDetail } from '../types'
+import { useNavigate } from 'react-router-dom'
 
 const DateBoxContainer = styled.div<{ $isCurrentMonth?: boolean }>`
   border-top: 0.1px solid #ccc;
@@ -12,13 +12,18 @@ const DateBoxContainer = styled.div<{ $isCurrentMonth?: boolean }>`
   overflow-x: hidden;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  cursor: pointer;
+
+  &:hover button {
+    visibility: visible;
+  }
 `
 
 const ContentContainer = styled.div`
   flex: 1;
   display: flex;
   flex-direction: column;
+  position: relative;
 `
 
 const Date = styled.div`
@@ -74,6 +79,25 @@ const TotalPrice = styled.div<{ $totalPrice: number }>`
   color: ${({ $totalPrice }) => ($totalPrice > 0 ? 'blue' : 'red')};
 `
 
+const EditButton = styled.button`
+  position: absolute;
+  right: 0;
+  top: 0;
+  padding: 0 0.1rem;
+  visibility: hidden;
+`
+
+const AddButton = styled.button`
+  visibility: hidden;
+`
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`
+
 interface Props {
   selectedDate?: string
   date: number
@@ -82,6 +106,21 @@ interface Props {
 }
 
 const DateBox = ({ selectedDate, date, detail, isCurrentMonth }: Props) => {
+  const navigate = useNavigate()
+
+  function handleContainerClick() {
+    navigate(`/detail?date=${selectedDate}`)
+  }
+
+  function handleEditBtnClick(e: React.MouseEvent<HTMLButtonElement>) {
+    e.stopPropagation()
+    navigate(`/edit?date=${selectedDate}`)
+  }
+
+  function handleAddBtnClick() {
+    navigate(`/write?date=${selectedDate}`)
+  }
+
   if (detail) {
     const { diary, account_book } = detail
 
@@ -90,33 +129,42 @@ const DateBox = ({ selectedDate, date, detail, isCurrentMonth }: Props) => {
     }, 0)
 
     return (
-      <Link to={`/detail?date=${selectedDate}`}>
-        <DateBoxContainer $isCurrentMonth={isCurrentMonth}>
-          <ContentContainer>
-            <Date>{date}</Date>
-            <Diary>
-              <span>{diary.title}</span>
-            </Diary>
-          </ContentContainer>
+      <DateBoxContainer
+        $isCurrentMonth={isCurrentMonth}
+        onClick={handleContainerClick}
+      >
+        <ContentContainer>
+          <Date>{date}</Date>
+          <EditButton onClick={handleEditBtnClick}>수정</EditButton>
+          <Diary>
+            <span>{diary.title}</span>
+          </Diary>
+        </ContentContainer>
 
-          <AccountBookList>
-            {Object.entries(account_book).map(([key, account]) => (
-              <AccountBookItem key={key}>
-                <Comment>{account.comment}</Comment>
-                <Price>₩ {account.price}</Price>
-              </AccountBookItem>
-            ))}
-          </AccountBookList>
+        <AccountBookList>
+          {Object.entries(account_book).map(([key, account]) => (
+            <AccountBookItem key={key}>
+              <Comment>{account.comment}</Comment>
+              <Price>₩ {account.price}</Price>
+            </AccountBookItem>
+          ))}
+        </AccountBookList>
 
-          <TotalPrice $totalPrice={totalPrice}>₩ {totalPrice}</TotalPrice>
-        </DateBoxContainer>
-      </Link>
+        <TotalPrice $totalPrice={totalPrice}>₩ {totalPrice}</TotalPrice>
+      </DateBoxContainer>
     )
   }
 
   return (
     <DateBoxContainer $isCurrentMonth={isCurrentMonth}>
-      <Date>{date}</Date>
+      <ContentContainer>
+        <Date>{date}</Date>
+      </ContentContainer>
+      {isCurrentMonth && (
+        <ButtonContainer>
+          <AddButton onClick={handleAddBtnClick}>+</AddButton>
+        </ButtonContainer>
+      )}
     </DateBoxContainer>
   )
 }

--- a/src/components/DateBox.tsx
+++ b/src/components/DateBox.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { ellipsisStyles } from '../assets/css/global'
 import { MonthDetail } from '../types'
@@ -11,6 +12,7 @@ const DateBoxContainer = styled.div<{ $isCurrentMonth?: boolean }>`
   overflow-x: hidden;
   display: flex;
   flex-direction: column;
+  height: 100%;
 `
 
 const ContentContainer = styled.div`
@@ -73,12 +75,13 @@ const TotalPrice = styled.div<{ $totalPrice: number }>`
 `
 
 interface Props {
+  selectedDate?: string
   date: number
   detail?: MonthDetail | null
   isCurrentMonth?: boolean
 }
 
-const DateBox = ({ date, detail, isCurrentMonth }: Props) => {
+const DateBox = ({ selectedDate, date, detail, isCurrentMonth }: Props) => {
   if (detail) {
     const { diary, account_book } = detail
 
@@ -87,25 +90,27 @@ const DateBox = ({ date, detail, isCurrentMonth }: Props) => {
     }, 0)
 
     return (
-      <DateBoxContainer $isCurrentMonth={isCurrentMonth}>
-        <ContentContainer>
-          <Date>{date}</Date>
-          <Diary>
-            <span>{diary.title}</span>
-          </Diary>
-        </ContentContainer>
+      <Link to={`/detail?date=${selectedDate}`}>
+        <DateBoxContainer $isCurrentMonth={isCurrentMonth}>
+          <ContentContainer>
+            <Date>{date}</Date>
+            <Diary>
+              <span>{diary.title}</span>
+            </Diary>
+          </ContentContainer>
 
-        <AccountBookList>
-          {Object.entries(account_book).map(([key, account]) => (
-            <AccountBookItem key={key}>
-              <Comment>{account.comment}</Comment>
-              <Price>₩ {account.price}</Price>
-            </AccountBookItem>
-          ))}
-        </AccountBookList>
+          <AccountBookList>
+            {Object.entries(account_book).map(([key, account]) => (
+              <AccountBookItem key={key}>
+                <Comment>{account.comment}</Comment>
+                <Price>₩ {account.price}</Price>
+              </AccountBookItem>
+            ))}
+          </AccountBookList>
 
-        <TotalPrice $totalPrice={totalPrice}>₩ {totalPrice}</TotalPrice>
-      </DateBoxContainer>
+          <TotalPrice $totalPrice={totalPrice}>₩ {totalPrice}</TotalPrice>
+        </DateBoxContainer>
+      </Link>
     )
   }
 

--- a/src/components/DateBox.tsx
+++ b/src/components/DateBox.tsx
@@ -1,0 +1,119 @@
+import styled from 'styled-components'
+import { ellipsisStyles } from '../assets/css/global'
+import { MonthDetail } from '../types'
+
+const DateBoxContainer = styled.div<{ $isCurrentMonth?: boolean }>`
+  border-top: 0.1px solid #ccc;
+  border-right: 0.1px solid #ccc;
+  padding: 0.5rem;
+  color: ${({ $isCurrentMonth }) => ($isCurrentMonth ? '#000' : '#ccc')};
+  font-size: 0.8rem;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+`
+
+const ContentContainer = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`
+
+const Date = styled.div`
+  margin-bottom: 0.5rem;
+  text-align: center;
+`
+
+const Diary = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.3rem;
+  padding: 0.2rem;
+  background-color: #b2e7e8;
+
+  > span {
+    ${ellipsisStyles}
+  }
+`
+
+const AccountBookList = styled.ul`
+  flex: 2;
+  overflow-y: auto;
+  padding: 0;
+  margin: 0.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+`
+
+const AccountBookItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+`
+
+const Comment = styled.span`
+  ${ellipsisStyles}
+  flex: 1;
+`
+
+const Price = styled.span`
+  ${ellipsisStyles}
+  text-align: right;
+  flex: 1;
+`
+
+const TotalPrice = styled.div<{ $totalPrice: number }>`
+  ${ellipsisStyles}
+  border-top: 1px solid black;
+  margin-top: 0.3rem;
+  padding-top: 0.3rem;
+  text-align: right;
+  color: ${({ $totalPrice }) => ($totalPrice > 0 ? 'blue' : 'red')};
+`
+
+interface Props {
+  date: number
+  detail?: MonthDetail | null
+  isCurrentMonth?: boolean
+}
+
+const DateBox = ({ date, detail, isCurrentMonth }: Props) => {
+  if (detail) {
+    const { diary, account_book } = detail
+
+    const totalPrice = Object.values(account_book).reduce((acc, cur) => {
+      return cur.is_income ? acc + cur.price : acc - cur.price
+    }, 0)
+
+    return (
+      <DateBoxContainer $isCurrentMonth={isCurrentMonth}>
+        <ContentContainer>
+          <Date>{date}</Date>
+          <Diary>
+            <span>{diary.title}</span>
+          </Diary>
+        </ContentContainer>
+
+        <AccountBookList>
+          {Object.entries(account_book).map(([key, account]) => (
+            <AccountBookItem key={key}>
+              <Comment>{account.comment}</Comment>
+              <Price>₩ {account.price}</Price>
+            </AccountBookItem>
+          ))}
+        </AccountBookList>
+
+        <TotalPrice $totalPrice={totalPrice}>₩ {totalPrice}</TotalPrice>
+      </DateBoxContainer>
+    )
+  }
+
+  return (
+    <DateBoxContainer $isCurrentMonth={isCurrentMonth}>
+      <Date>{date}</Date>
+    </DateBoxContainer>
+  )
+}
+
+export default DateBox

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,11 @@
+import Calendar from '../components/Calendar'
+
 const Home = () => {
-  return <div>Home</div>
+  return (
+    <main>
+      <Calendar />
+    </main>
+  )
 }
 
 export default Home

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,29 @@
+interface TotalPrice {
+  income_price: number
+  expense_price: number
+}
+
+interface Diary {
+  title: string
+  emotion: string
+  content: string
+}
+
+interface AccountBook {
+  [key: string]: {
+    comment: string
+    price: number
+    category: string
+    is_income: boolean
+  }
+}
+
+export interface MonthDetail {
+  diary: Diary
+  account_book: AccountBook
+}
+
+export interface Books {
+  [key: string]: MonthDetail | TotalPrice
+  total: TotalPrice
+}

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -1,0 +1,81 @@
+import { Dayjs } from 'dayjs'
+
+export interface MonthYear {
+  startDate: Dayjs
+  lastDate: number
+  month: string
+  year: string
+  calendarStartDate: number | null
+  calendarLastDate: number | null
+  weeksInMonth: number
+}
+
+// 현재 캘린더에 보여지는 총 주차 수를 반환하는 함수
+function getWeeksInMonth(firstDOW: number, totalDays: number): number {
+  return Math.ceil((totalDays + firstDOW) / 7)
+}
+
+// 현재 캘린더 정보
+function getCalendarDetails(startDate: Dayjs, lastDate: Dayjs) {
+  const calendarStartDate =
+    startDate.day() === 0 ? null : startDate.startOf('week').date()
+  const calendarLastDate =
+    lastDate.day() === 6 ? null : lastDate.endOf('week').date()
+
+  return { calendarStartDate, calendarLastDate }
+}
+
+// 당월 정보
+export function getMonthDetails(initialDate: Dayjs) {
+  const monthStartDate = initialDate.startOf('month')
+  const monthEndDate = initialDate.endOf('month')
+
+  const firstDOW = Number(monthStartDate.format('d'))
+  const lastDate = monthEndDate.date()
+
+  return {
+    monthStartDate,
+    monthEndDate,
+    firstDOW,
+    lastDate,
+  }
+}
+
+export function getMonthYearDetails(initialDate: Dayjs): MonthYear {
+  const { monthStartDate, monthEndDate, firstDOW, lastDate } =
+    getMonthDetails(initialDate)
+
+  const { calendarStartDate, calendarLastDate } = getCalendarDetails(
+    monthStartDate,
+    monthEndDate
+  )
+
+  const weeksInMonth = getWeeksInMonth(firstDOW, lastDate)
+
+  return {
+    startDate: monthStartDate,
+    lastDate,
+    month: monthStartDate.format('MM'),
+    year: monthStartDate.format('YYYY'),
+    calendarStartDate,
+    calendarLastDate,
+    weeksInMonth,
+  }
+}
+
+export function getNewMonthYear(
+  prevData: MonthYear,
+  monthIncrement: number
+): MonthYear {
+  const newMonthYear = prevData.startDate.clone().add(monthIncrement, 'months')
+  return getMonthYearDetails(newMonthYear)
+}
+
+// 시작일부터 마지막일까지 배열 생성
+export function getDateArray(
+  start: number | null,
+  end: number | null
+): number[] | null {
+  if (start === null || end === null) return null
+  return Array.from({ length: end - start + 1 }, (_, index) => start + index)
+}


### PR DESCRIPTION
+ `dayjs`, `react-query` 설치 및 설정

+  global style

+ `grid`로 캘린더 임시 UI 구현

+ 전월/익월 이동

+ 전월 데이터 prefetch

+ 각 셀 `/detail` 라우팅

+ 작성된 값이 있을 경우 셀에 hover 시 오른쪽 상단 수정 버튼 - `/edit` 라우팅

+ 작성된 값이 없을 경우 셀 가운데 추가 버튼 - `/write`라우팅

---

+ DB에 테스트로 만들어둔 uid 직접 연결 -> 로그인 정보 관리 회의 후 수정 예정!