### PR TITLE
feat: 가계부, 일기 수정 기능 추가

### DIFF
--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -115,5 +115,5 @@ export async function getBooks(year: string, month: string) {
 
 //가계부, 다이어리 저장 메소드
 export async function setBook(date: string, reqData: MonthDetail) {
-  return set(ref(db, `books/${userId}/${date}/`), reqData)
+  return set(ref(db, `books/${userId}/${date}/`), reqData).then(() => true)
 }

--- a/src/assets/css/Book.ts
+++ b/src/assets/css/Book.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+
+export const BookContainer = styled.div`
+  padding: 10px 30px;
+`
+
+export const BookDataContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  h2 {
+    margin: 0;
+  }
+`
+
+export const BookContentContainer = styled.div`
+  display: flex;
+  column-gap: 30px;
+
+  margin-top: 20px;
+`

--- a/src/components/AccountBook.tsx
+++ b/src/components/AccountBook.tsx
@@ -2,7 +2,6 @@ import { IAccountBook } from '../types'
 import styled from 'styled-components'
 import uuid from 'react-uuid'
 import Select from './Select'
-import { useEffect } from 'react'
 import { inputNumberCheck, inputNumberWithComma } from '../utils/\baccountBook'
 import { AiFillMinusCircle } from 'react-icons/ai'
 
@@ -88,75 +87,87 @@ const AccountBook = ({ setAccountBook, accountBookData }: AccountBookProps) => {
 
         <tbody>
           {accountBookData &&
-            Object.entries(accountBookData).map(([key, val]) => {
-              return (
-                <tr key={key}>
-                  <td>
-                    <Select
-                      name='is_income'
-                      handleOnChange={(e) => {
-                        accountBookData[key].is_income =
-                          e === 'true' ? true : false
+            Object.entries(accountBookData).map(([key, val]) => (
+              <tr key={key}>
+                <td>
+                  <Select
+                    name='is_income'
+                    handleOnChange={(e) => {
+                      accountBookData[key].is_income =
+                        e === 'true' ? true : false
 
-                        setAccountBook({ ...accountBookData })
-                      }}
-                      valData={isIncomeSelect}
-                      defaultVal={String(val.is_income)}
-                    />
-                  </td>
-                  <td>
-                    <Select
-                      name='category'
-                      handleOnChange={(e) => {
-                        accountBookData[key].category = e
+                      //memo, price, 카테고리 초기화
+                      accountBookData[key].memo = ''
+                      accountBookData[key].category =
+                        e === 'true'
+                          ? incomeSelect[0].value
+                          : expenseSelect[0].value
 
-                        setAccountBook({ ...accountBookData })
-                      }}
-                      valData={
-                        accountBookData[key].is_income
-                          ? incomeSelect
-                          : expenseSelect
-                      }
-                      defaultVal={val.category}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type='text'
-                      onChange={(e) => {
-                        accountBookData[key].memo = e.target.value
+                      accountBookData[key].price = 0
 
-                        setAccountBook({ ...accountBookData })
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type='text'
-                      value={
-                        accountBookData[key].price === 0
-                          ? ''
-                          : inputNumberWithComma(accountBookData[key].price)
-                      }
-                      onChange={(e) => {
-                        const numPrice = inputNumberCheck(e.target.value)
+                      setAccountBook({ ...accountBookData })
+                    }}
+                    valData={isIncomeSelect}
+                    defaultVal={String(accountBookData[key].is_income)}
+                  />
+                </td>
+                <td>
+                  <Select
+                    name='category'
+                    handleOnChange={(e) => {
+                      accountBookData[key].category = e
 
-                        accountBookData[key].price = Number(numPrice)
+                      //memo, price 초기화
+                      accountBookData[key].memo = ''
+                      accountBookData[key].price = 0
 
-                        setAccountBook({ ...accountBookData })
-                      }}
-                    />
-                  </td>
+                      setAccountBook({ ...accountBookData })
+                    }}
+                    valData={
+                      accountBookData[key].is_income
+                        ? incomeSelect
+                        : expenseSelect
+                    }
+                    defaultVal={accountBookData[key].category}
+                  />
+                </td>
+                <td>
+                  <input
+                    type='text'
+                    onChange={(e) => {
+                      accountBookData[key].memo = e.target.value
 
-                  <td>
-                    <AiFillMinusCircle
-                      onClick={() => deleteAccountBookItem(key)}
-                      style={{ cursor: 'pointer' }}
-                    />
-                  </td>
-                </tr>
-              )
-            })}
+                      setAccountBook({ ...accountBookData })
+                    }}
+                    value={accountBookData[key].memo}
+                  />
+                </td>
+                <td>
+                  <input
+                    type='text'
+                    value={
+                      accountBookData[key].price === 0
+                        ? ''
+                        : inputNumberWithComma(accountBookData[key].price)
+                    }
+                    onChange={(e) => {
+                      const numPrice = inputNumberCheck(e.target.value)
+
+                      accountBookData[key].price = Number(numPrice)
+
+                      setAccountBook({ ...accountBookData })
+                    }}
+                  />
+                </td>
+
+                <td>
+                  <AiFillMinusCircle
+                    onClick={() => deleteAccountBookItem(key)}
+                    style={{ cursor: 'pointer' }}
+                  />
+                </td>
+              </tr>
+            ))}
         </tbody>
       </AccountBookTable>
 

--- a/src/components/DateBox.tsx
+++ b/src/components/DateBox.tsx
@@ -115,7 +115,7 @@ const DateBox = ({ selectedDate, date, detail, isCurrentMonth }: Props) => {
 
   function handleEditBtnClick(e: React.MouseEvent<HTMLButtonElement>) {
     e.stopPropagation()
-    navigate(`/edit?date=${selectedDate}`)
+    navigate(`/edit?date=${selectedDate}`, { state: { detail } })
   }
 
   function handleAddBtnClick() {

--- a/src/components/Diary.tsx
+++ b/src/components/Diary.tsx
@@ -28,20 +28,18 @@ const Diary = ({ setDiary, diaryData }: DiaryProps) => {
       <DiaryColumnContainer>
         <input
           type='text'
+          value={diaryData.title}
           onChange={(e) => {
-            diaryData.title = e.target.value
-
-            setDiary(diaryData)
+            setDiary({ ...diaryData, title: e.target.value })
           }}
         />
 
         <h3>풀어쓰기 (선택)</h3>
         <textarea
           onChange={(e) => {
-            diaryData.content = e.target.value
-
-            setDiary(diaryData)
+            setDiary({ ...diaryData, content: e.target.value })
           }}
+          value={diaryData.content ?? ''}
         />
       </DiaryColumnContainer>
     </DiaryContainer>

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,5 +1,3 @@
-import styled from 'styled-components'
-
 type SelectValData = {
   label: string
   value: string
@@ -23,8 +21,8 @@ const Select = ({ handleOnChange, valData, name, defaultVal }: SelectProps) => {
       defaultValue={defaultVal}
       style={{ width: '80%' }}
     >
-      {valData.map((item, idx) => (
-        <option value={item.value} key={idx}>
+      {valData.map((item) => (
+        <option value={item.value} key={item.value}>
           {item.label}
         </option>
       ))}

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -1,77 +1,73 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { IDiary, IAccountBook } from '../types'
-import styled from 'styled-components'
+
 import AccountBook from '../components/AccountBook'
 import Diary from '../components/Diary'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { setBook } from '../api/firebase'
-
-const WriteContainer = styled.div`
-  padding: 10px 30px;
-`
-
-const WriteDateContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-
-  h2 {
-    margin: 0;
-  }
-`
-
-const WriteContentContainer = styled.div`
-  display: flex;
-  column-gap: 30px;
-
-  margin-top: 20px;
-`
+import {
+  BookContainer,
+  BookContentContainer,
+  BookDataContainer,
+} from '../assets/css/Book'
 
 const Write = () => {
-  const [accountBookData, setAccountBookData] = useState<IAccountBook>({})
-
+  const navigate = useNavigate()
   const location = useLocation()
 
   const date = location.search.split('=')[1]
+  const isEdit = location.pathname.split('/')[1]
 
-  const [diaryData, setDiaryData] = useState<IDiary>({
-    title: '',
-    content: '',
-    emotion: '',
-  })
+  const [accountBookData, setAccountBookData] = useState<IAccountBook>(
+    location.state?.detail.account_book ?? {}
+  )
 
-  const handleSavaClick = () => {
+  const [diaryData, setDiaryData] = useState<IDiary>(
+    location.state?.detail.diary ?? {
+      title: '',
+      content: '',
+      emotion: '',
+    }
+  )
+
+  const handleSavaClick = async () => {
     const reqData = {
       diary: diaryData,
       account_book: accountBookData,
     }
 
-    setBook(date.replaceAll('-', '/'), reqData)
+    const res = await setBook(date.replaceAll('-', '/'), reqData)
+
+    if (res) {
+      navigate(`/detail?date=${date}`)
+    }
   }
 
   return (
-    <WriteContainer>
-      <WriteDateContainer>
+    <BookContainer>
+      <BookDataContainer>
         <h2>{date}</h2>
         <button
           onClick={handleSavaClick}
           disabled={
             diaryData.title === '' ||
             Object.values(accountBookData).filter((item) => item.price === 0)
-              .length !== 0
+              .length !== 0 ||
+            Object.keys(accountBookData).length === 0
           }
         >
-          저장
+          {isEdit === 'edit' ? '수정하기' : '저장하기'}
         </button>
-      </WriteDateContainer>
+      </BookDataContainer>
 
-      <WriteContentContainer>
+      <BookContentContainer>
         <Diary diaryData={diaryData} setDiary={setDiaryData} />
         <AccountBook
           accountBookData={accountBookData}
           setAccountBook={setAccountBookData}
         />
-      </WriteContentContainer>
-    </WriteContainer>
+      </BookContentContainer>
+    </BookContainer>
   )
 }
 


### PR DESCRIPTION
> 가계부, 일기 수정 기능 추가

1. 수정 시 api 연결
    - 기존 api 사용, 덮어쓰기 가능
    - 파이어베이스 저장 후 반환값 추가
2. 데이터 세팅
3. 버튼 명칭 변경 -> edit ? 수정하기 : 저장하기
4. 캘린더에서 edit 라우팅 이동 시 state로 diary 이동 `{diary : {account_book: ~, diary: ~}}`
5. 작성/수정/상세보기 페이지에서 공통적으로 사용하는 styled-component div 파일로 묶음 -> `assets > css > Book.ts`
6. 가계부 - 항목, 카테고리 변경 시 메모, 가격 초기화 추가

> 수정/등록 후 api 성공 시 detail 페이지로 이동