### PR TITLE
feat: 가계부, 일기 조회 기능 추가

### DIFF
--- a/src/assets/css/Book.ts
+++ b/src/assets/css/Book.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 
+//book 관련 page styled component
 export const BookContainer = styled.div`
   padding: 10px 30px;
 `
@@ -18,4 +19,38 @@ export const BookContentContainer = styled.div`
   column-gap: 30px;
 
   margin-top: 20px;
+`
+
+//account book styled component
+export const AccountBookContainer = styled.div`
+  width: 60%;
+`
+
+export const AccountBookTable = styled.table`
+  width: 100%;
+
+  tr > td {
+    width: 20%;
+    text-align: center;
+  }
+
+  tr > td:nth-last-child(1) {
+    width: 5%;
+  }
+`
+
+//diary  styled component
+export const DiaryContainer = styled.div`
+  width: 40%;
+`
+
+export const DiaryColumnContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  row-gap: 20px;
+
+  textarea {
+    height: 300px;
+  }
 `

--- a/src/components/DateBox.tsx
+++ b/src/components/DateBox.tsx
@@ -110,7 +110,7 @@ const DateBox = ({ selectedDate, date, detail, isCurrentMonth }: Props) => {
   const navigate = useNavigate()
 
   function handleContainerClick() {
-    navigate(`/detail?date=${selectedDate}`)
+    navigate(`/detail?date=${selectedDate}`, { state: { detail } })
   }
 
   function handleEditBtnClick(e: React.MouseEvent<HTMLButtonElement>) {

--- a/src/components/book/AccountBookDetail.tsx
+++ b/src/components/book/AccountBookDetail.tsx
@@ -1,0 +1,35 @@
+import { IAccountBook } from '../../types'
+import AccountBookThead from './AccountBookThead'
+import { AccountBookContainer, AccountBookTable } from '../../assets/css/Book'
+
+interface AccountBookProps {
+  accountBookData: IAccountBook
+}
+
+const AccountBook = ({ accountBookData }: AccountBookProps) => {
+  return (
+    <AccountBookContainer>
+      <h3>가계부</h3>
+
+      <AccountBookTable>
+        <AccountBookThead />
+
+        <tbody>
+          {accountBookData &&
+            Object.entries(accountBookData).map(([key, val]) => (
+              <tr key={key}>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+
+                <td></td>
+              </tr>
+            ))}
+        </tbody>
+      </AccountBookTable>
+    </AccountBookContainer>
+  )
+}
+
+export default AccountBook

--- a/src/components/book/AccountBookDetail.tsx
+++ b/src/components/book/AccountBookDetail.tsx
@@ -1,12 +1,13 @@
 import { IAccountBook } from '../../types'
 import AccountBookThead from './AccountBookThead'
 import { AccountBookContainer, AccountBookTable } from '../../assets/css/Book'
+import { inputNumberWithComma } from '../../utils/\baccountBook'
 
 interface AccountBookProps {
   accountBookData: IAccountBook
 }
 
-const AccountBook = ({ accountBookData }: AccountBookProps) => {
+const AccountBookDetail = ({ accountBookData }: AccountBookProps) => {
   return (
     <AccountBookContainer>
       <h3>가계부</h3>
@@ -18,10 +19,10 @@ const AccountBook = ({ accountBookData }: AccountBookProps) => {
           {accountBookData &&
             Object.entries(accountBookData).map(([key, val]) => (
               <tr key={key}>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td>{val.is_income ? '수입' : '지출'}</td>
+                <td>{val.category}</td>
+                <td>{val.memo}</td>
+                <td>{inputNumberWithComma(val.price)}</td>
 
                 <td></td>
               </tr>
@@ -32,4 +33,4 @@ const AccountBook = ({ accountBookData }: AccountBookProps) => {
   )
 }
 
-export default AccountBook
+export default AccountBookDetail

--- a/src/components/book/AccountBookThead.tsx
+++ b/src/components/book/AccountBookThead.tsx
@@ -1,0 +1,15 @@
+const AccountBookThead = () => {
+  return (
+    <thead>
+      <tr>
+        <td>항목</td>
+        <td>카테고리</td>
+        <td>메모</td>
+        <td>가격</td>
+        <td></td>
+      </tr>
+    </thead>
+  )
+}
+
+export default AccountBookThead

--- a/src/components/book/AccountBookWrite.tsx
+++ b/src/components/book/AccountBookWrite.tsx
@@ -2,13 +2,23 @@ import { IAccountBook } from '../../types'
 import styled from 'styled-components'
 import uuid from 'react-uuid'
 import Select from '../common/Select'
-import { inputNumberCheck, inputNumberWithComma } from '../../utils/accountBook'
 import { AiFillMinusCircle } from 'react-icons/ai'
+import {
+  inputNumberCheck,
+  inputNumberWithComma,
+} from '../../utils/\baccountBook'
+import AccountBookThead from './AccountBookThead'
+import { AccountBookContainer, AccountBookTable } from '../../assets/css/Book'
 
 interface AccountBookProps {
   setAccountBook: React.Dispatch<React.SetStateAction<IAccountBook>>
   accountBookData: IAccountBook
 }
+
+const AddBtn = styled.button`
+  display: flex;
+  margin: 50px auto 0;
+`
 
 const isIncomeSelect = [
   { label: '수입', value: 'true' },
@@ -28,28 +38,6 @@ const expenseSelect = [
   { label: '생활비', value: '생활비' },
   { label: '교통비', value: '교통비' },
 ]
-
-const AccountBookContainer = styled.div`
-  width: 60%;
-`
-
-const AccountBookTable = styled.table`
-  width: 100%;
-
-  tr > td {
-    width: 20%;
-    text-align: center;
-  }
-
-  tr > td:nth-last-child(1) {
-    width: 5%;
-  }
-`
-
-const AddBtn = styled.button`
-  display: flex;
-  margin: 50px auto 0;
-`
 
 const AccountBook = ({ setAccountBook, accountBookData }: AccountBookProps) => {
   const AddAccountBookItem = () => {
@@ -75,15 +63,7 @@ const AccountBook = ({ setAccountBook, accountBookData }: AccountBookProps) => {
       <h3>가계부</h3>
 
       <AccountBookTable>
-        <thead>
-          <tr>
-            <td>항목</td>
-            <td>카테고리</td>
-            <td>메모</td>
-            <td>가격</td>
-            <td></td>
-          </tr>
-        </thead>
+        <AccountBookThead />
 
         <tbody>
           {accountBookData &&

--- a/src/components/book/DiaryDetail.tsx
+++ b/src/components/book/DiaryDetail.tsx
@@ -1,0 +1,23 @@
+import { IDiary } from '../../types'
+import { DiaryColumnContainer, DiaryContainer } from '../../assets/css/Book'
+
+interface DiaryProps {
+  diaryData: IDiary
+}
+
+const DiaryDetail = ({ diaryData }: DiaryProps) => {
+  return (
+    <DiaryContainer>
+      <h3>오늘의 요약 (필수)</h3>
+
+      {diaryData.title}
+      <DiaryColumnContainer>
+        <h3 style={{ margin: '50px 0px 0px' }}>풀어쓰기 (선택)</h3>
+
+        {diaryData.content}
+      </DiaryColumnContainer>
+    </DiaryContainer>
+  )
+}
+
+export default DiaryDetail

--- a/src/components/book/DiaryWrite.tsx
+++ b/src/components/book/DiaryWrite.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components'
 import { IDiary } from '../../types'
 import { DiaryColumnContainer, DiaryContainer } from '../../assets/css/Book'
 
@@ -20,7 +19,7 @@ const DiaryWrite = ({ setDiary, diaryData }: DiaryProps) => {
           }}
         />
 
-        <h3>풀어쓰기 (선택)</h3>
+        <h3 style={{ margin: '30px 0px 0px' }}>풀어쓰기 (선택)</h3>
         <textarea
           onChange={(e) => {
             setDiary({ ...diaryData, content: e.target.value })

--- a/src/components/book/DiaryWrite.tsx
+++ b/src/components/book/DiaryWrite.tsx
@@ -1,27 +1,13 @@
 import styled from 'styled-components'
 import { IDiary } from '../../types'
-
-const DiaryContainer = styled.div`
-  width: 40%;
-`
-
-const DiaryColumnContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  row-gap: 20px;
-
-  textarea {
-    height: 300px;
-  }
-`
+import { DiaryColumnContainer, DiaryContainer } from '../../assets/css/Book'
 
 interface DiaryProps {
   setDiary: React.Dispatch<React.SetStateAction<IDiary>>
   diaryData: IDiary
 }
 
-const Diary = ({ setDiary, diaryData }: DiaryProps) => {
+const DiaryWrite = ({ setDiary, diaryData }: DiaryProps) => {
   return (
     <DiaryContainer>
       <h3>오늘의 요약 (필수)</h3>
@@ -46,4 +32,4 @@ const Diary = ({ setDiary, diaryData }: DiaryProps) => {
   )
 }
 
-export default Diary
+export default DiaryWrite

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,5 +1,45 @@
+import { useLocation, useNavigate } from 'react-router-dom'
+import {
+  BookContainer,
+  BookContentContainer,
+  BookDataContainer,
+} from '../assets/css/Book'
+import DiaryDetail from '../components/book/DiaryDetail'
+import AccountBookDetail from '../components/book/AccountBookDetail'
+
 const Detail = () => {
-  return <div>Detail</div>
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const date = location.search.split('=')[1]
+
+  const accountBookData = location.state.detail.account_book
+
+  const diaryData = location.state.detail.diary
+
+  const detail = location.state
+
+  return (
+    <BookContainer>
+      <BookDataContainer>
+        <h2>{date}</h2>
+        <button
+          onClick={() =>
+            navigate(`/edit?date=${date}`, {
+              state: location.state,
+            })
+          }
+        >
+          수정
+        </button>
+      </BookDataContainer>
+
+      <BookContentContainer>
+        <DiaryDetail diaryData={diaryData} />
+        <AccountBookDetail accountBookData={accountBookData} />
+      </BookContentContainer>
+    </BookContainer>
+  )
 }
 
 export default Detail

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -17,8 +17,6 @@ const Detail = () => {
 
   const diaryData = location.state.detail.diary
 
-  const detail = location.state
-
   return (
     <BookContainer>
       <BookDataContainer>

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 import { IDiary, IAccountBook } from '../types'
-
-import AccountBook from '../components/book/AccountBook'
-import Diary from '../components/book/Diary'
+import AccountBookWrite from '../components/book/AccountBookWrite'
+import DiaryWrite from '../components/book/DiaryWrite'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { setBook } from '../api/firebase'
 import {
@@ -61,8 +60,8 @@ const Write = () => {
       </BookDataContainer>
 
       <BookContentContainer>
-        <Diary diaryData={diaryData} setDiary={setDiaryData} />
-        <AccountBook
+        <DiaryWrite diaryData={diaryData} setDiary={setDiaryData} />
+        <AccountBookWrite
           accountBookData={accountBookData}
           setAccountBook={setAccountBookData}
         />

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -15,7 +15,6 @@ const Write = () => {
   const location = useLocation()
 
   const date = location.search.split('=')[1]
-  const isEdit = location.pathname.split('/')[1]
 
   const [accountBookData, setAccountBookData] = useState<IAccountBook>(
     location.state?.detail.account_book ?? {}
@@ -38,7 +37,11 @@ const Write = () => {
     const res = await setBook(date.replaceAll('-', '/'), reqData)
 
     if (res) {
-      navigate(`/detail?date=${date}`)
+      navigate(`/detail?date=${date}`, {
+        state: {
+          detail: reqData,
+        },
+      })
     }
   }
 
@@ -55,7 +58,7 @@ const Write = () => {
             Object.keys(accountBookData).length === 0
           }
         >
-          {isEdit === 'edit' ? '수정하기' : '저장하기'}
+          저장
         </button>
       </BookDataContainer>
 


### PR DESCRIPTION
1. 가계부, 일기 조회 기능 추가
- DateBox.tsx에서 상세페이지 이동 시 `detail:{account_book: ~, diary: ~}` state로 넘겨줌.
- 수정 후 상세보기 페이지 이동 
- 데이터 세팅
- 버튼 명칭 변경
- 상세보기 페이지에서도 수정 페이지로 이동 추가

2. refactor: 작성 Book 공용 스타일드 컴포넌트 분리