### PR TITLE
feat: 설정 페이지 관련 컴포넌트 추가

### DIFF
--- a/src/components/custom/Category.tsx
+++ b/src/components/custom/Category.tsx
@@ -1,0 +1,13 @@
+interface CategoryProps {
+  category: string
+
+  setCategory: (data: string) => void
+
+  isEdit: boolean
+}
+
+const Category = ({ category, setCategory, isEdit }: CategoryProps) => {
+  return <div>{category}</div>
+}
+
+export default Category

--- a/src/components/custom/DailyResult.tsx
+++ b/src/components/custom/DailyResult.tsx
@@ -1,0 +1,16 @@
+interface DailyResultProps {
+  dailyResult: string
+
+  setDailyResult: (data: string) => void
+  isEdit: boolean
+}
+
+const DailyResult = ({
+  dailyResult,
+  setDailyResult,
+  isEdit,
+}: DailyResultProps) => {
+  return <div>{dailyResult}</div>
+}
+
+export default DailyResult

--- a/src/components/custom/ExpectedLimit.tsx
+++ b/src/components/custom/ExpectedLimit.tsx
@@ -1,0 +1,19 @@
+import { IExpectedLimit } from '../../types'
+
+interface ExpectedLimitProps {
+  expectedLimit: IExpectedLimit
+
+  setExpectedLimit: (data: IExpectedLimit) => void
+
+  isEdit: boolean
+}
+
+const ExpectedLimit = ({
+  expectedLimit,
+  setExpectedLimit,
+  isEdit,
+}: ExpectedLimitProps) => {
+  return <div>{expectedLimit.price}</div>
+}
+
+export default ExpectedLimit

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,8 +1,104 @@
+import { useQuery } from '@tanstack/react-query'
+import { getCustom } from '../api/firebase'
+import { Custom } from '../types'
+import { useEffect, useState } from 'react'
+
+import ExpectedLimit from '../components/custom/ExpectedLimit'
+import DailyResult from '../components/custom/DailyResult'
+import Category from '../components/custom/Category'
+import styled from 'styled-components'
+
+const SettingContainer = styled.div`
+  padding: 10px;
+`
+
+const TitleContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 20px 0;
+
+  div > h2 {
+    margin: 0;
+    margin-bottom: 5px;
+  }
+`
+
 const Setting = () => {
+  const [isEdit, setIsEdit] = useState(false)
+
+  const [customData, setCustomData] = useState<Custom>({
+    category: '',
+    daily_result: '',
+    expected_limit: {
+      is_possible: true,
+      price: 300000,
+    },
+  })
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['custom'],
+    queryFn: () => getCustom(),
+  })
+
+  useEffect(() => {
+    if (data) {
+      setCustomData(data)
+    }
+  }, [data])
+
+  // 로딩 스피너 추후 변경
+  if (!data || isLoading) return <div>Loading...</div>
+
   return (
-    <div>
-      Setting <button>회원 탈퇴하기</button>
-    </div>
+    <SettingContainer>
+      <TitleContainer
+        style={{ display: 'flex', justifyContent: 'space-between' }}
+      >
+        <div>
+          <h2>설정</h2>
+          <span>회원탈퇴와 커스텀을 할 수 있는 페이지입니다.</span>
+        </div>
+        <div>
+          {isEdit && (
+            <button
+              style={{ marginRight: '10px' }}
+              onClick={() => setIsEdit(false)}
+            >
+              취소하기
+            </button>
+          )}
+          <button
+            onClick={() => {
+              setIsEdit(!isEdit)
+            }}
+          >
+            {isEdit ? '저장하기' : '수정하기'}
+          </button>
+        </div>
+      </TitleContainer>
+
+      <DailyResult
+        dailyResult={customData.daily_result}
+        setDailyResult={(data) =>
+          setCustomData({ ...customData, daily_result: data })
+        }
+        isEdit
+      />
+      <ExpectedLimit
+        expectedLimit={customData.expected_limit}
+        setExpectedLimit={(data) => {
+          setCustomData({ ...customData, expected_limit: data })
+        }}
+        isEdit
+      />
+      <Category
+        category={customData.category}
+        setCategory={(data) => setCustomData({ ...customData, category: data })}
+        isEdit
+      />
+      <button>회원 탈퇴하기</button>
+    </SettingContainer>
   )
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,3 +45,10 @@ export interface IExpectedLimit {
   is_possible: boolean
   price: number
 }
+
+export interface Custom {
+  category: string
+  daily_result: string
+
+  expected_limit: IExpectedLimit
+}


### PR DESCRIPTION
[설정 페이지 관련]
- `DailyResult.tsx` : 수입/지출/수입-지출 캘린더 일간 데이터 어떻게 보여질지
- `ExpectedLimit.tsx` : 한달 예상한도
- `Category.tsx` : 카테고리 커스텀 (수입/지출)
- 회원탈퇴 버튼 추가 (기능 개발 X)
- 저장/취소 버튼 추가 (기능 개발 X)
- custom 관련 데이터 불러오기
- 각 컴포넌트 `Props`
   - 수정중인지 
   - 컴포넌트에 맞는 데이터
   - 데이터 세팅 메소드
