### PR TITLE
fix: 로컬스토리지-카테고리추가 및 메소드 정의

### DIFF
--- a/src/components/context/AuthContext.tsx
+++ b/src/components/context/AuthContext.tsx
@@ -30,11 +30,6 @@ export function AuthContextProvider({
     onUserStateChange((user: UserCredential['user']) => {
       if (user) {
         setUser(user)
-
-        const nickName = user.email?.split('@')[0]
-
-        nickName && localStorage.setItem('nickName', nickName)
-        localStorage.setItem('user', user.uid)
       } else {
         localStorage.clear() //구글 로그인 풀렸을 경우 로컬 지워줌
       }


### PR DESCRIPTION
로컬 스토리지 -> 카테고리 추가 (`income` / `expense`)
로그인 시 로컬스토리지 세팅 메소드 정의해서 호출 -> `setUser()`, `getUser()` 안에서