### PR TITLE
feat: 해당 월 전체 수입,지출 가격 업데이트 추가

### DIFF
--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -9,7 +9,7 @@ import {
   UserCredential,
   deleteUser,
 } from '@firebase/auth'
-import { Custom, IFixedExpense, MonthDetail } from '../types'
+import { Custom, IFixedExpense, MonthDetail, TotalPrice } from '../types'
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -192,7 +192,21 @@ export async function setFixedExpense(
   }
 }
 
+//가계부 total 값 업데이트
+export async function setTotalPrice(date: string[], reqData: TotalPrice) {
+  return set(
+    ref(db, `${userId}/books/${date[0]}/${date[1]}/total`),
+    reqData
+  ).then(() => true)
+}
+
 //가계부, 다이어리 저장 메소드
-export async function setBook(date: string, reqData: MonthDetail) {
-  return set(ref(db, `${userId}/books/${date}/`), reqData).then(() => true)
+export async function setBook(
+  date: string,
+  reqData: MonthDetail,
+  totalPrice: TotalPrice
+) {
+  return set(ref(db, `${userId}/books/${date}/`), reqData)
+    .then(() => true)
+    .catch(() => setTotalPrice(date.split('-'), totalPrice))
 }

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -32,7 +32,6 @@ const Write = () => {
   )
 
   const handleSavaClick = async () => {
-    console.log(total)
 
     let income = total ? total.income_price : 0
     let expense = total ? total.expense_price : 0

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -38,7 +38,6 @@ const Write = () => {
 
     //수입/지출 데이터 가공
     Object.entries(accountBookData).map(([key, value]) => {
-      console.log(key, value)
       if (value.is_income) {
         income += value.price
       } else {

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -3,18 +3,21 @@ import { IDiary, IAccountBook } from '../types'
 import AccountBookWrite from '../components/book/AccountBookWrite'
 import DiaryWrite from '../components/book/DiaryWrite'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { setBook } from '../api/firebase'
+import { setBook, setTotalPrice } from '../api/firebase'
 import {
   BookContainer,
   BookContentContainer,
   BookDataContainer,
 } from '../assets/css/Book'
+import { useMonthYearContext } from '../components/context/MonthYearContext'
 
 const Write = () => {
   const navigate = useNavigate()
   const location = useLocation()
 
   const date = location.search.split('=')[1]
+
+  const { total } = useMonthYearContext()
 
   const [accountBookData, setAccountBookData] = useState<IAccountBook>(
     location.state?.detail.account_book ?? {}
@@ -29,19 +32,49 @@ const Write = () => {
   )
 
   const handleSavaClick = async () => {
-    const reqData = {
-      diary: diaryData,
-      account_book: accountBookData,
-    }
+    console.log(total)
 
-    const res = await setBook(date.replaceAll('-', '/'), reqData)
+    let income = total ? total.income_price : 0
+    let expense = total ? total.expense_price : 0
 
-    if (res) {
-      navigate(`/detail?date=${date}`, {
-        state: {
-          detail: reqData,
+    //수입/지출 데이터 가공
+    Object.entries(accountBookData).map(([key, value]) => {
+      console.log(key, value)
+      if (value.is_income) {
+        income += value.price
+      } else {
+        expense += value.price
+      }
+    })
+
+    const resSetTotalPrice = await setTotalPrice(date.split('-'), {
+      income_price: income,
+      expense_price: expense,
+    }) //total price update
+
+    if (resSetTotalPrice) {
+      //update 성공 시 가계부, 일기 set api call
+      const reqData = {
+        diary: diaryData,
+        account_book: accountBookData,
+      }
+
+      const resSetBook = await setBook(
+        date.replaceAll('-', '/'),
+        {
+          diary: diaryData,
+          account_book: accountBookData,
         },
-      })
+        total //에러 시 total price 롤백하기 위한 값
+      )
+
+      if (resSetBook) {
+        navigate(`/detail?date=${date}`, {
+          state: {
+            detail: reqData,
+          },
+        })
+      }
     }
   }
 


### PR DESCRIPTION
`useMonthYearContext` 에서 `total` 받아오고
저장 버튼 클릭 시 `accountData`를 map 돌면서 `is_income` 값을 따져 맞는 변수(expense, income)누적 시켜준다. 
(expense, income 은 total이 없을 시 각 각 0으로 초기화되는거 추가)

`setTotalPrice`함수를 통해 `totalPrice` 먼저 update.
그 후 가계부, 다이어리를 저장한다.
만약 가계부, 다이어리 저장하다 에러가 난다면, 기존 total 값으로 롤백하기 위해 `setTotalPrice` 메소드를 호출한다.