### PR TITLE
refactor/write: 카테고리 커스텀 값으로 세팅 및 작성/수정 시 리액트쿼리 사용

### DIFF
--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -78,7 +78,7 @@ async function setUser(userCredential: UserCredential['user']) {
       },
       category: {
         expense: '식비,쇼핑,생활비,교통비',
-        income: '월급, 용돈, 이월',
+        income: '월급,용돈,이월,적금',
       },
       daily_result: 'revenue',
     },

--- a/src/components/book/AccountBookWrite.tsx
+++ b/src/components/book/AccountBookWrite.tsx
@@ -6,6 +6,7 @@ import { AiFillMinusCircle } from 'react-icons/ai'
 import { inputNumberCheck, inputNumberWithComma } from '../../utils/accountBook'
 import AccountBookThead from './AccountBookThead'
 import { AccountBookContainer, AccountBookTable } from '../../assets/css/Book'
+import { formatSelectOptions } from '../../utils'
 
 interface AccountBookProps {
   setAccountBook: React.Dispatch<React.SetStateAction<IAccountBook>>
@@ -22,14 +23,14 @@ const isIncomeSelect = [
   { label: '지출', value: 'false' },
 ]
 
-const incomeSelect = [
+const incomeDefault = [
   { label: '월급', value: '월급' },
   { label: '용돈', value: '용돈' },
   { label: '이월', value: '이월' },
   { label: '기타', value: '기타' },
 ]
 
-const expenseSelect = [
+const expenseDefault = [
   { label: '식비', value: '식비' },
   { label: '쇼핑', value: '쇼핑' },
   { label: '생활비', value: '생활비' },
@@ -37,6 +38,17 @@ const expenseSelect = [
 ]
 
 const AccountBook = ({ setAccountBook, accountBookData }: AccountBookProps) => {
+  const categoryIncome = localStorage.getItem('category_income')
+  const categoryExpense = localStorage.getItem('category_expense')
+
+  const incomeSelect = categoryIncome
+    ? formatSelectOptions(categoryIncome.split(','))
+    : incomeDefault
+
+  const expenseSelect = categoryExpense
+    ? formatSelectOptions(categoryExpense.split(','))
+    : expenseDefault
+
   const AddAccountBookItem = () => {
     //가계부 아이템 하나 추가
     setAccountBook((prev) => ({

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -45,8 +45,6 @@ const Write = () => {
         total //에러 시 total price 롤백하기 위한 값
       ),
     onSuccess: () => {
-      console.log(date.split('-'))
-
       queryClient.invalidateQueries({
         queryKey: ['books', date.split('-')[0], date.split('-')[1]],
       })

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -10,6 +10,7 @@ import {
   BookDataContainer,
 } from '../assets/css/Book'
 import { useMonthYearContext } from '../components/context/MonthYearContext'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 const Write = () => {
   const navigate = useNavigate()
@@ -31,8 +32,36 @@ const Write = () => {
     }
   )
 
-  const handleSavaClick = async () => {
+  const queryClient = useQueryClient()
 
+  const { mutate: saveBook } = useMutation({
+    mutationFn: () =>
+      setBook(
+        date.replaceAll('-', '/'),
+        {
+          diary: diaryData,
+          account_book: accountBookData,
+        },
+        total //에러 시 total price 롤백하기 위한 값
+      ),
+    onSuccess: () => {
+      console.log(date.split('-'))
+
+      queryClient.invalidateQueries({
+        queryKey: ['books', date.split('-')[0], date.split('-')[1]],
+      })
+      navigate(`/detail?date=${date}`, {
+        state: {
+          detail: {
+            diary: diaryData,
+            account_book: accountBookData,
+          },
+        },
+      })
+    },
+  })
+
+  const handleSavaClick = async () => {
     let income = total ? total.income_price : 0
     let expense = total ? total.expense_price : 0
 
@@ -52,27 +81,7 @@ const Write = () => {
 
     if (resSetTotalPrice) {
       //update 성공 시 가계부, 일기 set api call
-      const reqData = {
-        diary: diaryData,
-        account_book: accountBookData,
-      }
-
-      const resSetBook = await setBook(
-        date.replaceAll('-', '/'),
-        {
-          diary: diaryData,
-          account_book: accountBookData,
-        },
-        total //에러 시 total price 롤백하기 위한 값
-      )
-
-      if (resSetBook) {
-        navigate(`/detail?date=${date}`, {
-          state: {
-            detail: reqData,
-          },
-        })
-      }
+      saveBook()
     }
   }
 


### PR DESCRIPTION
[카테고리]
- 로컬스토리지 저장된 커스텀 값 읽어와서 select 데이터 세팅

[리액트 쿼리]
- 상황 : 작성/수정 후 홈으로 이동하면 새로고침을 해야 바뀐 데이터가 보인다.
- 해결 : 리액트쿼리로 캘린더에서 데이터 불러올 때와 동일한 키로 하여 데이터를 새로 받아올 수 있도록 `queryClient.invalidateQueries` 사용