### PR TITLE
refactor: total price 업데이트 리액트 쿼리 사용

### DIFF
--- a/src/hooks/book/useSetBook.tsx
+++ b/src/hooks/book/useSetBook.tsx
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { setBook } from '../../api/firebase'
+import { useNavigate } from 'react-router-dom'
+import { MonthDetail, TotalPrice } from '../../types'
+
+export const useSetBook = (
+  date: string,
+  total: TotalPrice,
+  reqData: MonthDetail | null
+) => {
+  const queryClient = useQueryClient()
+
+  const navigate = useNavigate()
+
+  const { mutate } = useMutation({
+    mutationFn: () =>
+      setBook(
+        date.replaceAll('-', '/'),
+        reqData,
+        total //에러 시 total price 롤백하기 위한 값
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['books', date.split('-')[0], date.split('-')[1]],
+      })
+      if (reqData) {
+        //작성 혹은 수정
+        navigate(`/detail?date=${date}`, {
+          state: {
+            detail: reqData,
+          },
+        })
+      } else {
+        //삭제
+        navigate('/')
+      }
+    },
+  })
+  return { mutate }
+}

--- a/src/hooks/book/useSetTotalPrice.tsx
+++ b/src/hooks/book/useSetTotalPrice.tsx
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query'
+import { calcTotalPrice } from '../../utils/accountBook'
+import { setTotalPrice } from '../../api/firebase'
+import { IAccountBook, TotalPrice } from '../../types'
+
+export const useSetTotalPrice = (
+  date: string,
+  total: TotalPrice,
+  accountBookData: IAccountBook,
+  isDelete: boolean,
+  handleSuccess: () => void
+) => {
+  const { mutate: updateTotalPrice } = useMutation({
+    mutationFn: () => {
+      const calcTotal = calcTotalPrice(accountBookData, total, isDelete)
+
+      return setTotalPrice(date.split('-'), calcTotal) //total price update
+    },
+    onSuccess: () => handleSuccess(),
+  })
+  return { updateTotalPrice }
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -45,16 +45,17 @@ const Detail = () => {
     },
   })
 
-  const handleDeleteBook = async () => {
-    const calcTotal = calcTotalPrice(accountBookData, total, true) //세번째 파라미터가 true로 누적 시 마이너스로 계산된다
+  const { mutate: updateTotalPrice } = useMutation({
+    mutationFn: () => {
+      const calcTotal = calcTotalPrice(accountBookData, total, false)
 
-    const resSetTotalPrice = await setTotalPrice(date.split('-'), calcTotal) //total price update
-
-    if (resSetTotalPrice) {
-      //update 성공 시 삭제
+      return setTotalPrice(date.split('-'), calcTotal) //total price update
+    },
+    onSuccess: () => {
+      //update 성공 시 가계부, 일기 set api call
       deleteBook()
-    }
-  }
+    },
+  })
 
   return (
     <BookContainer>
@@ -90,7 +91,7 @@ const Detail = () => {
 
             <div>
               <button onClick={onClose}>취소</button>
-              <button onClick={handleDeleteBook}>확인</button>
+              <button onClick={() => updateTotalPrice()}>확인</button>
             </div>
           </ConfirmContainer>
         </Modal>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -6,13 +6,12 @@ import {
 } from '../assets/css/Book'
 import DiaryDetail from '../components/book/DiaryDetail'
 import AccountBookDetail from '../components/book/AccountBookDetail'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { setBook, setTotalPrice } from '../api/firebase'
 import { useMonthYearContext } from '../components/context/MonthYearContext'
-import { calcTotalPrice } from '../utils/accountBook'
 import useModal from '../hooks/useModal'
 import Modal from '../components/common/Modal'
 import { ConfirmContainer } from '../assets/css/Confirm'
+import { useSetBook } from '../hooks/book/useSetBook'
+import { useSetTotalPrice } from '../hooks/book/useSetTotalPrice'
 
 const Detail = () => {
   const navigate = useNavigate()
@@ -26,36 +25,17 @@ const Detail = () => {
 
   const { isOpen, onClose, onOpen } = useModal()
 
-  const queryClient = useQueryClient()
-
   const { total } = useMonthYearContext()
 
-  const { mutate: deleteBook } = useMutation({
-    mutationFn: () =>
-      setBook(
-        date.replaceAll('-', '/'),
-        null,
-        total //에러 시 total price 롤백하기 위한 값
-      ),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['books', date.split('-')[0], date.split('-')[1]],
-      })
-      navigate('/')
-    },
-  })
+  const { mutate: deleteBook } = useSetBook(date, total, null)
 
-  const { mutate: updateTotalPrice } = useMutation({
-    mutationFn: () => {
-      const calcTotal = calcTotalPrice(accountBookData, total, false)
-
-      return setTotalPrice(date.split('-'), calcTotal) //total price update
-    },
-    onSuccess: () => {
-      //update 성공 시 가계부, 일기 set api call
-      deleteBook()
-    },
-  })
+  const { updateTotalPrice } = useSetTotalPrice(
+    date,
+    total,
+    accountBookData,
+    true, //total price 빼기
+    deleteBook
+  )
 
   return (
     <BookContainer>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -86,7 +86,7 @@ const Detail = () => {
         <Modal onClose={onClose}>
           <ConfirmContainer>
             <h3>{date} 글을 삭제하시겠습니까?</h3>
-            <h5>삭제 시 다이어리와 가계부는 삭제됩니다. </h5>
+            <h5>삭제 시 일기와 가계부는 삭제됩니다. </h5>
 
             <div>
               <button onClick={onClose}>취소</button>

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -2,19 +2,17 @@ import { useState } from 'react'
 import { IDiary, IAccountBook } from '../types'
 import AccountBookWrite from '../components/book/AccountBookWrite'
 import DiaryWrite from '../components/book/DiaryWrite'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { setBook, setTotalPrice } from '../api/firebase'
+import { useLocation } from 'react-router-dom'
 import {
   BookContainer,
   BookContentContainer,
   BookDataContainer,
 } from '../assets/css/Book'
 import { useMonthYearContext } from '../components/context/MonthYearContext'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { calcTotalPrice } from '../utils/accountBook'
+import { useSetBook } from '../hooks/book/useSetBook'
+import { useSetTotalPrice } from '../hooks/book/useSetTotalPrice'
 
 const Write = () => {
-  const navigate = useNavigate()
   const location = useLocation()
 
   const date = location.search.split('=')[1]
@@ -33,44 +31,18 @@ const Write = () => {
     }
   )
 
-  const queryClient = useQueryClient()
-
-  const { mutate: saveBook } = useMutation({
-    mutationFn: () =>
-      setBook(
-        date.replaceAll('-', '/'),
-        {
-          diary: diaryData,
-          account_book: accountBookData,
-        },
-        total //에러 시 total price 롤백하기 위한 값
-      ),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['books', date.split('-')[0], date.split('-')[1]],
-      })
-      navigate(`/detail?date=${date}`, {
-        state: {
-          detail: {
-            diary: diaryData,
-            account_book: accountBookData,
-          },
-        },
-      })
-    },
+  const { mutate: saveBook } = useSetBook(date, total, {
+    diary: diaryData,
+    account_book: accountBookData,
   })
 
-  const { mutate: updateTotalPrice } = useMutation({
-    mutationFn: () => {
-      const calcTotal = calcTotalPrice(accountBookData, total, false)
-
-      return setTotalPrice(date.split('-'), calcTotal) //total price update
-    },
-    onSuccess: () => {
-      //update 성공 시 가계부, 일기 set api call
-      saveBook()
-    },
-  })
+  const { updateTotalPrice } = useSetTotalPrice(
+    date,
+    total,
+    accountBookData,
+    false, //total price 더하기
+    saveBook
+  )
 
   return (
     <BookContainer>

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -60,23 +60,24 @@ const Write = () => {
     },
   })
 
-  const handleSavaClick = async () => {
-    const calcTotal = calcTotalPrice(accountBookData, total, false)
+  const { mutate: updateTotalPrice } = useMutation({
+    mutationFn: () => {
+      const calcTotal = calcTotalPrice(accountBookData, total, false)
 
-    const resSetTotalPrice = await setTotalPrice(date.split('-'), calcTotal) //total price update
-
-    if (resSetTotalPrice) {
+      return setTotalPrice(date.split('-'), calcTotal) //total price update
+    },
+    onSuccess: () => {
       //update 성공 시 가계부, 일기 set api call
       saveBook()
-    }
-  }
+    },
+  })
 
   return (
     <BookContainer>
       <BookDataContainer>
         <h2>{date}</h2>
         <button
-          onClick={handleSavaClick}
+          onClick={() => updateTotalPrice()}
           disabled={
             diaryData.title === '' ||
             Object.values(accountBookData).filter((item) => item.price === 0)


### PR DESCRIPTION
- 글 삭제 시 컨펌창 컨텐츠 수정

[total price update 리액트 쿼리 사용]
 - 작성/수정
 - 삭제
 - `hooks > book` 폴더 생성 후 커스텀 훅 정의
    - total price 업데이트나 book 저장하는 리액트쿼리가 동일하다 (navigate 혹은 total price 계산 메소드 t/f 값 빼고)
    - 각 각을 커스텀 훅으로 분리 후 중복 코드를 제거하고 필요한 값은 파라미터로 받아서 기존과 동일하게 작동하도록 정의했다.
