### PR TITLE
refactor: 로그아웃 후 다른 계정으로 로그인 시 쿼리 refetch

### DIFF
--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -128,10 +128,10 @@ export async function UserOut() {
 
 // 캘린더 데이터 가져오기
 export async function getBooks(year: string, month: string) {
+  const uid = localStorage.getItem('user')
+
   try {
-    const snapshot = await get(
-      child(ref(db), `${userId}/books/${year}/${month}`)
-    )
+    const snapshot = await get(child(ref(db), `${uid}/books/${year}/${month}`))
 
     if (snapshot.exists()) {
       return snapshot.val()

--- a/src/components/calendar/DateBox.tsx
+++ b/src/components/calendar/DateBox.tsx
@@ -131,9 +131,9 @@ const DateBox = ({ selectedDate, date, detail, isCurrentMonth }: Props) => {
 
   // 일간 내역 커스텀에 따라 totalPrice 계산
   function getTotalPrice(accountBook: IAccountBook) {
-    let totalPrice
+    let totalPrice = 0
 
-    switch (custom.daily_result) {
+    switch (custom?.daily_result) {
       case 'revenue':
         totalPrice = Object.values(accountBook).reduce((acc, cur) => {
           return cur.is_income ? acc + cur.price : acc - cur.price

--- a/src/components/context/AuthContext.tsx
+++ b/src/components/context/AuthContext.tsx
@@ -11,12 +11,14 @@ type Auth = {
   user: UserCredential['user'] | undefined
   login: () => void
   logout: () => Promise<boolean>
+  isLoggedIn: boolean
 }
 
 const AuthContext = createContext<Auth>({
   user: undefined,
   login: () => {},
   logout: () => Promise.resolve(false),
+  isLoggedIn: false,
 })
 
 export function AuthContextProvider({
@@ -25,6 +27,7 @@ export function AuthContextProvider({
   children: React.ReactNode
 }) {
   const [user, setUser] = useState<UserCredential['user']>()
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
 
   useEffect(() => {
     onUserStateChange((user: UserCredential['user']) => {
@@ -34,10 +37,13 @@ export function AuthContextProvider({
         nickName && localStorage.setItem('nickName', nickName)
 
         localStorage.setItem('user', user.uid)
+
         setUser(user)
+        setIsLoggedIn(true)
       } else {
         localStorage.clear() //구글 로그인 풀렸을 경우 로컬 지워줌
         queryClient.clear() // 리액트 쿼리 캐시 초기화
+        setIsLoggedIn(false)
       }
     })
   }, [])
@@ -54,7 +60,7 @@ export function AuthContextProvider({
   }
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, logout, isLoggedIn }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/components/context/AuthContext.tsx
+++ b/src/components/context/AuthContext.tsx
@@ -5,7 +5,7 @@ import {
   onUserStateChange,
 } from '../../api/firebase'
 import { UserCredential } from '@firebase/auth'
-import { useLocation } from 'react-router-dom'
+import { queryClient } from '../../api/react-query'
 
 type Auth = {
   user: UserCredential['user'] | undefined
@@ -37,6 +37,7 @@ export function AuthContextProvider({
         setUser(user)
       } else {
         localStorage.clear() //구글 로그인 풀렸을 경우 로컬 지워줌
+        queryClient.clear() // 리액트 쿼리 캐시 초기화
       }
     })
   }, [])

--- a/src/components/sidebar/ExpectedLimit.tsx
+++ b/src/components/sidebar/ExpectedLimit.tsx
@@ -35,17 +35,14 @@ const ExpectedLimit = ({ expectedLimit }: Props) => {
   const incomePrice = total?.income_price || 0
   const expensePrice = total?.expense_price || 0
 
-  // (수입 - 지출) / 예상 한도
-  const percentage = Math.round(
-    (Math.abs(incomePrice - expensePrice) / price) * 100
-  )
+  const percentage = Math.round((expensePrice / price) * 100)
 
   const isExcess = percentage > 100 // 한도 초과 플래그
   const percentageWidth = isExcess ? 100 : percentage
 
   return isPossible ? (
     <section>
-      <SidebarTitle title='예상 한도' />
+      <SidebarTitle title='예상 지출 한도' />
       <Indicator $isExcess={isExcess}>
         <span>
           {inputNumberWithComma(Math.abs(incomePrice - expensePrice))}


### PR DESCRIPTION
+ 구글 인증 풀렸을 경우 쿼리 캐시 초기화

+ `getTotalPrice` 함수에서 custom이 undefined일 때 처리

+ 사이드바 예상 한도 -> `예상 지출 한도`로 이름 변경, 지출 금액만 계산하도록 수정

+ 다른 계정으로 로그인 시 이전 로그인했던 계정의 데이터가 남아있던 이슈

   + 원인: 로그아웃 후 다른 계정으로 로그인 시 useQuery 재실행이 안됨
  
   + 해결

      + `AuthContext`에 로그인 상태(`isLoggedIn`) 추가

      + `MonthYearContext`에 `isLoggedIn`이 `true`로 변경되면 useQuery를 다시 실행하도록 로직 추가