### PR TITLE
fix:수정 시 total price 업데이트 누적 버그 해결

### DIFF
--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { IDiary, IAccountBook } from '../types'
 import AccountBookWrite from '../components/book/AccountBookWrite'
 import DiaryWrite from '../components/book/DiaryWrite'
@@ -11,6 +11,7 @@ import {
 import { useMonthYearContext } from '../components/context/MonthYearContext'
 import { useSetBook } from '../hooks/book/useSetBook'
 import { useSetTotalPrice } from '../hooks/book/useSetTotalPrice'
+import { calcTotalPrice } from '../utils/accountBook'
 
 const Write = () => {
   const location = useLocation()
@@ -18,6 +19,11 @@ const Write = () => {
   const date = location.search.split('=')[1]
 
   const { total } = useMonthYearContext()
+
+  const [modifyPrice, setModifyPrice] = useState({
+    income_price: 0,
+    expense_price: 0,
+  }) //수정 중일때 사용하는 price state
 
   const [accountBookData, setAccountBookData] = useState<IAccountBook>(
     location.state?.detail.account_book ?? {}
@@ -38,11 +44,19 @@ const Write = () => {
 
   const { updateTotalPrice } = useSetTotalPrice(
     date,
-    total,
+    location.state ? modifyPrice : total, //edit ? 계산된 total : total
     accountBookData,
     false, //total price 더하기
     saveBook
   )
+
+  useEffect(() => {
+    if (location.state) {
+      //수정 시 있는 값에서 줄이거나 늘릴 때 기존꺼에서 누적되는 현상 발생 변수 별도로 두는걸로 해결
+
+      setModifyPrice(calcTotalPrice(accountBookData, total, true)) //isDelete true로 줘서 수입을 빼주고, 지출은 더해준다. 함수 재사용
+    }
+  }, [])
 
   return (
     <BookContainer>


### PR DESCRIPTION
글 수정 시 기존 값이 작아지거나 늘어도 누적되는 현상 발생

해당 글에 수입, 지출을 따로 계산 후 total에서 빼준 income, expense를 리턴받는다.(기존 함수 사용, `setTotalPrice`) 
=> `useEffect` 에서 계산
리턴 받은 값을 state 변수,`modifyPrice`에 저장 후 커스텀 훅 파라미터에 `수정 중 ? modifyPrice : 기존 total`을 넘겨줬다.