### PR TITLE
fix: 카테고리 커스텀 수정 시 로컬스토리지 업데이트

### DIFF
--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -9,7 +9,13 @@ import {
   UserCredential,
   deleteUser,
 } from '@firebase/auth'
-import { Custom, IFixedExpense, MonthDetail, TotalPrice } from '../types'
+import {
+  Custom,
+  ICategory,
+  IFixedExpense,
+  MonthDetail,
+  TotalPrice,
+} from '../types'
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -32,10 +38,7 @@ const userId = localStorage.getItem('user')
 const db = getDatabase(app)
 
 //localStorage 세팅
-export const localStorageSetting = (category: {
-  income: string
-  expense: string
-}) => {
+export const localStorageSetting = (category: ICategory) => {
   localStorage.setItem('category_income', category.income)
 
   localStorage.setItem('category_expense', category.expense)

--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -32,7 +32,10 @@ const userId = localStorage.getItem('user')
 const db = getDatabase(app)
 
 //localStorage 세팅
-const localStorageSetting = (category: { income: string; expense: string }) => {
+export const localStorageSetting = (category: {
+  income: string
+  expense: string
+}) => {
   localStorage.setItem('category_income', category.income)
 
   localStorage.setItem('category_expense', category.expense)

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,5 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { UserOut, getCustom, setCustom } from '../api/firebase'
+import {
+  UserOut,
+  getCustom,
+  localStorageSetting,
+  setCustom,
+} from '../api/firebase'
 import { Custom } from '../types'
 import { useEffect, useState } from 'react'
 
@@ -64,6 +69,9 @@ const Setting = () => {
       queryClient.invalidateQueries({
         queryKey: ['custom'],
       })
+
+      //로컬스토리지 변경된 카테고리 업데이트
+      localStorageSetting(customData.category)
       setIsEdit(false)
     },
   })
@@ -131,9 +139,11 @@ const Setting = () => {
         />
         <CustomCategory
           category={customData.category}
-          setCategory={(data) =>
+          setCategory={(data) => {
+            console.log(data)
+
             setCustomData({ ...customData, category: data })
-          }
+          }}
           isEdit={isEdit}
         />
       </CustomContainer>


### PR DESCRIPTION
커스텀 수정 시 카테고리가 로컬스토리지에 업데이트가 되는게 빠져있어서 글 작성/수정 할 때 카테고리가 커스텀대로 나오지 않음
로컬스토리 업데이트하는 메소드가 파이어베이스 파일에 정의가 되어있어 `import` 해서 업데이트해줌 :) 