### PR TITLE
refactor: 고정 지출 에러 시 롤백 및 공통 로직 분리

### DIFF
--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -16,6 +16,7 @@ import {
   MonthDetail,
   TotalPrice,
 } from '../types'
+import { initialCustom } from '../constants/config'
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -77,17 +78,7 @@ async function setUser(userCredential: UserCredential['user']) {
     //TODO : default 값 정의 필요
 
     email: email,
-    custom: {
-      expected_limit: {
-        is_possible: true,
-        price: 300000,
-      },
-      category: {
-        expense: '식비,쇼핑,생활비,교통비',
-        income: '월급,용돈,이월,적금',
-      },
-      daily_result: 'revenue',
-    },
+    custom: initialCustom,
   }
 
   return set(ref(db, `${uid}/users`), reqData).then(() =>
@@ -155,11 +146,10 @@ export async function getCustom() {
 
   try {
     const snapshot = await get(child(ref(db), `${uid}/users/custom`))
-
     if (snapshot.exists()) {
       return snapshot.val()
     } else {
-      throw new Error('custom이 존재하지 않습니다.')
+      return initialCustom
     }
   } catch (error) {
     console.error(error)

--- a/src/api/firebase.tsx
+++ b/src/api/firebase.tsx
@@ -174,7 +174,7 @@ export async function setCustom(reqData: Custom) {
 // 고정 지출 저장
 export async function setFixedExpense(
   reqData: IFixedExpense,
-  deleteList: string[]
+  deleteList?: string[]
 ) {
   const databaseRef = ref(db, `${userId}/users/custom/fixed_expense`)
 
@@ -182,12 +182,14 @@ export async function setFixedExpense(
     // newData를 사용하여 데이터 업데이트
     await update(databaseRef, reqData)
 
-    // deleteList에 있는 각 키에 null 값을 설정하여 삭제
-    const deletes: { [key: string]: null } = {}
-    deleteList.forEach((key) => {
-      deletes[key] = null
-    })
-    await update(databaseRef, deletes)
+    if (deleteList) {
+      // deleteList에 있는 각 키에 null 값을 설정하여 삭제
+      const deletes: { [key: string]: null } = {}
+      deleteList.forEach((key) => {
+        deletes[key] = null
+      })
+      await update(databaseRef, deletes)
+    }
 
     return { success: true }
   } catch (error) {

--- a/src/components/calendar/DateBox.tsx
+++ b/src/components/calendar/DateBox.tsx
@@ -3,8 +3,7 @@ import { ellipsisStyles } from '../../assets/css/global'
 import { IAccountBook, MonthDetail } from '../../types'
 import { useNavigate } from 'react-router-dom'
 import { inputNumberWithComma } from '../../utils/accountBook'
-import { useQuery } from '@tanstack/react-query'
-import { getCustom } from '../../api/firebase'
+import useCustom from '../../hooks/custom/useCustom'
 
 const DateBoxContainer = styled.div<{ $isCurrentMonth?: boolean }>`
   border-top: 0.1px solid #ccc;
@@ -110,11 +109,7 @@ interface Props {
 
 const DateBox = ({ selectedDate, date, detail, isCurrentMonth }: Props) => {
   const navigate = useNavigate()
-
-  const { data: custom } = useQuery({
-    queryKey: ['custom'],
-    queryFn: () => getCustom(),
-  })
+  const { custom } = useCustom()
 
   function handleContainerClick() {
     navigate(`/detail?date=${selectedDate}`, { state: { detail } })

--- a/src/components/sidebar/FixedExpenseModal.tsx
+++ b/src/components/sidebar/FixedExpenseModal.tsx
@@ -9,7 +9,7 @@ import Select from '../common/Select'
 import { setFixedExpense } from '../../api/firebase'
 import { ellipsisStyles } from '../../assets/css/global'
 import Modal from '../common/Modal'
-import { formatSelectOptions } from '../../utils'
+import { deepCopy, formatSelectOptions } from '../../utils'
 import usePatchCustom from '../../hooks/custom/usePatchCustom'
 
 const HeaderContainer = styled.div`
@@ -74,8 +74,8 @@ const FixedExpenseModal = ({ data, setData, category, onClose }: Props) => {
   const oneYearLater = dayjs().add(1, 'year').format('YYYY-MM-DD')
 
   useEffect(() => {
-    setNewData(JSON.parse(JSON.stringify(data)))
-    setOriginData(JSON.parse(JSON.stringify(data)))
+    setNewData(deepCopy(data))
+    setOriginData(deepCopy(data))
   }, [data])
 
   const { patchCustom } = usePatchCustom({
@@ -115,7 +115,7 @@ const FixedExpenseModal = ({ data, setData, category, onClose }: Props) => {
   }
 
   function handleCancle() {
-    setNewData(JSON.parse(JSON.stringify(originData)))
+    setNewData(deepCopy(originData))
     handleEditMode()
   }
 

--- a/src/components/sidebar/FixedExpenseModal.tsx
+++ b/src/components/sidebar/FixedExpenseModal.tsx
@@ -88,6 +88,7 @@ const FixedExpenseModal = ({ data, setData, category, onClose }: Props) => {
       setData(newData)
       handleEditMode()
     },
+    onError: () => setFixedExpense(originData),
   })
 
   function handleAdd() {

--- a/src/components/sidebar/FixedExpenseModal.tsx
+++ b/src/components/sidebar/FixedExpenseModal.tsx
@@ -8,9 +8,9 @@ import { paymentTypeOptions } from '../../constants'
 import Select from '../common/Select'
 import { setFixedExpense } from '../../api/firebase'
 import { ellipsisStyles } from '../../assets/css/global'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
 import Modal from '../common/Modal'
 import { formatSelectOptions } from '../../utils'
+import usePatchCustom from '../../hooks/custom/usePatchCustom'
 
 const HeaderContainer = styled.div`
   position: relative;
@@ -78,13 +78,9 @@ const FixedExpenseModal = ({ data, setData, category, onClose }: Props) => {
     setOriginData(JSON.parse(JSON.stringify(data)))
   }, [data])
 
-  const queryClient = useQueryClient()
-  const { mutate: onSave } = useMutation({
-    mutationFn: () => setFixedExpense(newData, deleteList),
+  const { patchCustom } = usePatchCustom({
+    onMutate: () => setFixedExpense(newData, deleteList),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['custom'],
-      })
       setData(newData)
       handleEditMode()
     },
@@ -270,7 +266,7 @@ const FixedExpenseModal = ({ data, setData, category, onClose }: Props) => {
           <>
             <button onClick={handleCancle}>취소</button>
             <button
-              onClick={() => onSave()}
+              onClick={() => patchCustom()}
               disabled={
                 Object.values(newData).filter((item) => item.price === 0)
                   .length !== 0

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,9 +1,8 @@
 import { styled } from 'styled-components'
 import FixedExpense from './FixedExpense'
 import ExpectedLimit from './ExpectedLimit'
-import { useQuery } from '@tanstack/react-query'
 import MonthlyFinancialOverview from './MonthlyFinancialOverview'
-import { getCustom } from '../../api/firebase'
+import useCustom from '../../hooks/custom/useCustom'
 
 const Container = styled.section`
   display: flex;
@@ -30,22 +29,19 @@ const SubContainer = styled.div`
 `
 
 const Sidebar = () => {
-  const { data, isLoading } = useQuery({
-    queryKey: ['custom'],
-    queryFn: () => getCustom(),
-  })
+  const { custom, isLoading } = useCustom()
 
   // 로딩 스피너 추후 변경
-  if (!data || isLoading) return <div>Loading...</div>
+  if (!custom || isLoading) return <div>Loading...</div>
 
   return (
     <Container>
       <FixedExpense
-        fixedExpense={data.fixed_expense}
-        category={data.category.expense}
+        fixedExpense={custom.fixed_expense}
+        category={custom.category.expense}
       />
       <SubContainer>
-        <ExpectedLimit expectedLimit={data.expected_limit} />
+        <ExpectedLimit expectedLimit={custom.expected_limit} />
         <MonthlyFinancialOverview />
       </SubContainer>
     </Container>

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,0 +1,11 @@
+export const initialCustom = {
+  expected_limit: {
+    is_possible: true,
+    price: 300000,
+  },
+  category: {
+    expense: '식비,쇼핑,생활비,교통비',
+    income: '월급,용돈,이월,적금',
+  },
+  daily_result: 'revenue',
+}

--- a/src/hooks/custom/useCustom.tsx
+++ b/src/hooks/custom/useCustom.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { getCustom } from '../../api/firebase'
+
+const useCustom = () => {
+  const { data: custom, isLoading } = useQuery({
+    queryKey: ['custom'],
+    queryFn: () => getCustom(),
+  })
+
+  return { custom, isLoading }
+}
+
+export default useCustom

--- a/src/hooks/custom/usePatchCustom.tsx
+++ b/src/hooks/custom/usePatchCustom.tsx
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query'
+import { queryClient } from '../../api/react-query'
+
+interface usePatchCustomProps {
+  onMutate: () => Promise<unknown>
+  onSuccess: () => void
+  onError?: () => Promise<unknown>
+}
+
+const usePatchCustom = ({
+  onMutate,
+  onSuccess,
+  onError,
+}: usePatchCustomProps) => {
+  const { mutate: patchCustom } = useMutation({
+    mutationFn: onMutate,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['custom'],
+      })
+      onSuccess()
+    },
+    onError: onError,
+  })
+
+  return { patchCustom }
+}
+
+export default usePatchCustom

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -12,6 +12,8 @@ import { useNavigate } from 'react-router-dom'
 import { ConfirmContainer } from '../assets/css/Confirm'
 import usePatchCustom from '../hooks/custom/usePatchCustom'
 import useCustom from '../hooks/custom/useCustom'
+import { deepCopy } from '../utils'
+import { initialCustom } from '../constants/config'
 
 const SettingContainer = styled.div`
   padding: 10px;
@@ -41,16 +43,9 @@ const Setting = () => {
   const [isEdit, setIsEdit] = useState(false)
   const { isOpen, onClose, onOpen } = useModal()
 
-  const [customData, setCustomData] = useState<Custom>({
-    category: { expense: '', income: '' },
-    daily_result: '',
-    expected_limit: {
-      is_possible: true,
-      price: 300000,
-    },
-  })
+  const [customData, setCustomData] = useState<Custom>(initialCustom)
 
-  const [originData, setOriginData] = useState({})
+  const [originData, setOriginData] = useState<Custom>(initialCustom)
 
   const { custom, isLoading } = useCustom()
 
@@ -61,19 +56,19 @@ const Setting = () => {
       localStorageSetting(customData.category)
       setIsEdit(false)
     },
-    onError: () => setCustom(custom),
+    onError: () => setCustom(originData),
   })
 
   useEffect(() => {
     if (custom) {
-      setCustomData(custom)
-      setOriginData(JSON.parse(JSON.stringify(custom)))
+      setCustomData(deepCopy(custom))
+      setOriginData(deepCopy(custom))
     }
   }, [custom])
 
   const handleCancle = () => {
     setIsEdit(false)
-    setCustomData(JSON.parse(JSON.stringify(originData)))
+    setCustomData(deepCopy(originData))
   }
 
   const handleUserOut = async () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,11 @@
 export function formatSelectOptions(arr: string[]) {
   return arr.map((item) => ({ label: item, value: item }))
 }
+
+// 객체 깊은 복사
+// JSON.stringify와 JSON.parse를 사용하므로 함수, 정규표현식 등은 복사되지 않음
+export function deepCopy<T>(obj: T): T {
+  const jsonString = JSON.stringify(obj)
+  const copy = JSON.parse(jsonString)
+  return copy
+}


### PR DESCRIPTION
+ 고정 지출 에러 시 롤백

+ 'custom' 쿼리 키 공통 로직 분리

   + useCustom: `useQuery`를 사용하는 함수로서, 'custom' 쿼리를 가져오는 역할

   + usePatchCustom: `useMutation`를 사용하여 'custom' 쿼리를 업데이트하는 역할

+ 객체 복사 함수(`deepCopy`) 분리

+ 초기 커스텀 값이 사용되는 곳이 많아서 `initialCustom`으로 분리
