### PR TITLE
feat: form 요소 컴포넌트

### DIFF
--- a/src/assets/css/form.ts
+++ b/src/assets/css/form.ts
@@ -1,0 +1,47 @@
+import { css, DefaultTheme } from 'styled-components'
+
+export type TextAlign = 'center' | 'left' | 'right'
+
+export const formFieldStyles = ($textAlign: TextAlign) => css`
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0.5rem;
+  border: 2px solid ${({ theme }) => theme.color.gray1};
+  border-radius: 0.5rem;
+  background-color: ${({ theme }) => theme.color.white};
+
+  color: ${({ theme }) => theme.color.black};
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  font-weight: ${({ theme }) => theme.fontWeight.medium};
+  text-align: ${$textAlign || 'center'};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.gray1};
+  }
+
+  &:focus {
+    outline: none;
+    border: 2px solid ${({ theme }) => theme.color.primary.main};
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.color.gray0};
+    border: 2px solid ${({ theme }) => theme.color.gray0};
+    color: ${({ theme }) => theme.color.gray1};
+  }
+`
+
+export const formFieldViewModeStyles = (
+  theme: DefaultTheme,
+  $viewMode: boolean
+) => css`
+  &:disabled {
+    background-color: ${$viewMode
+      ? theme.color.secondary.main
+      : theme.color.gray0};
+    border: 2px solid
+      ${$viewMode ? theme.color.secondary.main : theme.color.gray0};
+    color: ${$viewMode ? theme.color.primary.main : theme.color.gray1};
+    font-weight: ${({ theme }) => theme.fontWeight.medium};
+  }
+`

--- a/src/assets/css/form.ts
+++ b/src/assets/css/form.ts
@@ -5,13 +5,13 @@ export type TextAlign = 'center' | 'left' | 'right'
 export const formFieldStyles = ($textAlign: TextAlign) => css`
   box-sizing: border-box;
   width: 100%;
-  padding: 0.5rem;
+  padding: 0.75rem;
   border: 2px solid ${({ theme }) => theme.color.gray1};
   border-radius: 0.5rem;
   background-color: ${({ theme }) => theme.color.white};
 
-  color: ${({ theme }) => theme.color.black};
-  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: ${({ theme }) => theme.color.gray3};
+  font-size: ${({ theme }) => theme.fontSize.base};
   font-weight: ${({ theme }) => theme.fontWeight.medium};
   text-align: ${$textAlign || 'center'};
 
@@ -41,7 +41,7 @@ export const formFieldViewModeStyles = (
       : theme.color.gray0};
     border: 2px solid
       ${$viewMode ? theme.color.secondary.main : theme.color.gray0};
-    color: ${$viewMode ? theme.color.primary.main : theme.color.gray1};
+    color: ${$viewMode ? theme.color.primary.dark : theme.color.gray1};
     font-weight: ${({ theme }) => theme.fontWeight.medium};
   }
 `

--- a/src/assets/icons/chevronDown.svg
+++ b/src/assets/icons/chevronDown.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+<path d="M5 7.00006L8 10.0001L11 7.00006" stroke="#616161" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/chevronUp.svg
+++ b/src/assets/icons/chevronUp.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+<path d="M5 9.00006L8 6.00006L11 9.00006" stroke="#616161" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,162 @@
+import { useState, useRef, useEffect, useMemo } from 'react'
+import styled, { css } from 'styled-components'
+import {
+  formFieldStyles,
+  formFieldViewModeStyles,
+  TextAlign,
+} from '../../assets/css/form'
+import { ReactComponent as ChevronUp } from '../../assets/icons/chevronUp.svg'
+import { ReactComponent as ChevronDown } from '../../assets/icons/chevronDown.svg'
+
+interface Options {
+  label: string
+  value: string
+}
+
+const DropdownContainer = styled.div`
+  position: relative;
+  cursor: pointer;
+`
+
+const DropdownInput = styled.input<{
+  $viewMode: boolean
+  $textAlign: TextAlign
+  $isOpen: boolean
+}>`
+  cursor: pointer;
+  ${({ $textAlign }) => formFieldStyles($textAlign)}
+  ${({ theme, $viewMode }) => formFieldViewModeStyles(theme, $viewMode)};
+
+  ${({ theme, $isOpen }) =>
+    $isOpen &&
+    css`
+      outline: none;
+      border: 2px solid ${theme.color.primary.main};
+    `}
+`
+
+const ChevronIcon = styled.div<{ disabled: boolean }>`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
+
+  path {
+    stroke: ${({ theme, disabled }) =>
+      disabled ? theme.color.gray1 : theme.color.primary.gray3};
+  }
+`
+
+const DropdownList = styled.ul`
+  position: absolute;
+  top: 100%;
+  left: 0;
+
+  box-sizing: border-box;
+  padding: 0;
+  width: 100%;
+  border-radius: 0.5rem;
+  background-color: ${({ theme }) => theme.color.white};
+  box-shadow: 1px 1px 3px 0px rgba(97, 97, 97, 0.5);
+
+  li {
+    padding: 0.75rem;
+  }
+
+  li:hover {
+    background-color: ${({ theme }) => theme.color.secondary.main};
+    color: ${({ theme }) => theme.color.primary.dark};
+  }
+`
+
+interface DropdownProps {
+  options: Options[]
+  defaultValue: string
+  onChange: (option: string) => void
+  placeholder?: string
+  disabled?: boolean
+  viewMode?: boolean
+  textAlign?: TextAlign
+}
+
+function Dropdown({
+  options,
+  defaultValue,
+  onChange,
+  placeholder,
+  disabled = false,
+  viewMode = false,
+  textAlign = 'center',
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const defaultOption = useMemo(
+    () => options.find((option) => option.value === defaultValue),
+    [options, defaultValue]
+  )
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen)
+  }
+
+  const selectOption = (option: string) => {
+    onChange(option)
+    setIsOpen(false)
+  }
+
+  useEffect(() => {
+    // 외부 클릭에 대한 이벤트를 처리
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('click', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+    }
+  }, [])
+
+  return (
+    <DropdownContainer ref={dropdownRef}>
+      <DropdownInput
+        onClick={toggleDropdown}
+        value={defaultOption ? defaultOption.label : ''}
+        disabled={viewMode || disabled}
+        placeholder={viewMode ? '' : placeholder}
+        readOnly
+        $textAlign={textAlign}
+        $viewMode={viewMode}
+        $isOpen={isOpen}
+      />
+      {!viewMode && (
+        <ChevronIcon
+          disabled={disabled}
+          onClick={(e) => {
+            e.stopPropagation()
+            toggleDropdown()
+          }}
+        >
+          {isOpen ? <ChevronUp /> : <ChevronDown />}
+        </ChevronIcon>
+      )}
+      {!viewMode && isOpen && (
+        <DropdownList>
+          {options.map((item) => (
+            <li key={item.value} onClick={() => selectOption(item.value)}>
+              {item.label}
+            </li>
+          ))}
+        </DropdownList>
+      )}
+    </DropdownContainer>
+  )
+}
+
+export default Dropdown

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components'
+import {
+  formFieldStyles,
+  formFieldViewModeStyles,
+  TextAlign,
+} from '../../assets/css/form'
+
+const InputContainer = styled.input<{
+  $viewMode: boolean
+  $textAlign: TextAlign
+}>`
+  ${({ $textAlign }) => formFieldStyles($textAlign)}
+  ${({ theme, $viewMode }) => formFieldViewModeStyles(theme, $viewMode)}
+`
+
+interface InputProps {
+  type: string
+  placeholder?: string
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  disabled?: boolean
+  viewMode?: boolean
+  textAlign?: TextAlign
+}
+
+const Input = ({
+  type,
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  viewMode = false,
+  textAlign = 'left',
+}: InputProps) => {
+  return (
+    <InputContainer
+      type={type}
+      placeholder={viewMode ? '' : placeholder}
+      value={value}
+      onChange={onChange}
+      disabled={viewMode || disabled}
+      $viewMode={viewMode}
+      $textAlign={textAlign}
+    />
+  )
+}
+
+export default Input

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components'
+import {
+  formFieldStyles,
+  formFieldViewModeStyles,
+  TextAlign,
+} from '../../assets/css/form'
+
+const TextareaContainer = styled.textarea<{
+  $viewMode: boolean
+  $textAlign: TextAlign
+}>`
+  ${({ $textAlign }) => formFieldStyles($textAlign)}
+  ${({ theme, $viewMode }) => formFieldViewModeStyles(theme, $viewMode)}
+
+  resize: none;
+`
+
+interface TextareaProps {
+  placeholder?: string
+  value: string
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
+  disabled?: boolean
+  rows?: number
+  viewMode?: boolean
+  textAlign?: TextAlign
+}
+
+const Textarea = ({
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  rows = 5,
+  viewMode = false,
+  textAlign = 'left',
+}: TextareaProps) => {
+  return (
+    <TextareaContainer
+      rows={rows}
+      placeholder={viewMode ? '' : placeholder}
+      value={value}
+      onChange={onChange}
+      disabled={viewMode || disabled}
+      $viewMode={viewMode}
+      $textAlign={textAlign}
+    />
+  )
+}
+
+export default Textarea


### PR DESCRIPTION
+ Input / Textarea / Dropdown 컴포넌트 공통 props로 `viewMode` 있음
  ```jsx
   interface Props {
     ...
     viewMode?: boolean
   }
   ```

+ 읽기 전용 페이지(/detail) 등에서 viewMode 값을 `true`로 할당하여 사용

   + viewMode `true` 시 아래 디자인 적용
    <img width="508" alt="image" src="https://github.com/wjdgml3092/harumoa/assets/102649010/b8e4eb41-acae-40d2-af4a-037f14f66787">
