### PR TITLE
refactor: 설정 페이지 저장 버튼 조건부 활성화 등

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^18.2.17",
         "dayjs": "^1.11.10",
         "firebase": "^10.7.0",
+        "lodash.isequal": "^4.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.12.0",
@@ -28,6 +29,9 @@
         "styled-components": "^6.1.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/lodash.isequal": "^4.5.8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4770,6 +4774,21 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -12679,6 +12698,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "^18.2.17",
     "dayjs": "^1.11.10",
     "firebase": "^10.7.0",
+    "lodash.isequal": "^4.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",
@@ -47,5 +48,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/lodash.isequal": "^4.5.8"
   }
 }

--- a/src/components/book/AccountBook.tsx
+++ b/src/components/book/AccountBook.tsx
@@ -65,7 +65,8 @@ const AccountBook = ({
         [uuid()]: {
           is_income: type === 'income' ? true : false,
           price: 0,
-          category: '식비',
+          category:
+            type === 'income' ? incomeSelect[0].value : expenseSelect[0].value,
           memo: '',
         },
       }))

--- a/src/components/book/AccountBook.tsx
+++ b/src/components/book/AccountBook.tsx
@@ -68,6 +68,7 @@ const AccountBook = ({
           category:
             type === 'income' ? incomeSelect[0].value : expenseSelect[0].value,
           memo: '',
+          payment_type: 'cash',
         },
       }))
   }

--- a/src/components/book/AccountBookTable.tsx
+++ b/src/components/book/AccountBookTable.tsx
@@ -4,6 +4,7 @@ import Input from '../common/Input'
 import Dropdown from '../common/Dropdown'
 import { IAccountBook, Options } from '../../types'
 import DeleteButton from './DeleteButton'
+import { paymentTypeOptions } from '../../constants'
 
 const TableContainer = styled.table`
   width: 100%;
@@ -18,6 +19,7 @@ const TableContainer = styled.table`
 
     td {
       padding: 0.56rem 0.5rem;
+      padding-left: 0;
     }
   }
 
@@ -38,7 +40,7 @@ const TableContainer = styled.table`
 const KRWICon = styled.span<{ $viewMode: boolean }>`
   position: absolute;
   left: 1rem;
-  top: 1.4rem;
+  top: 1.35rem;
 
   color: ${({ theme, $viewMode }) =>
     $viewMode ? theme.color.primary.dark : theme.color.gray3};
@@ -65,9 +67,10 @@ const AccountBookTable = ({
     <TableContainer>
       <thead>
         <tr>
-          <td width='25%'>카테고리</td>
-          <td width='25%'>금액</td>
-          <td width='50%'>메모</td>
+          <td width='20%'>카테고리</td>
+          <td width='20%'>금액</td>
+          <td width='20%'>지출 수단</td>
+          <td width='40%'>메모</td>
           {!viewMode && <td></td>}
         </tr>
       </thead>
@@ -83,11 +86,6 @@ const AccountBookTable = ({
                   <Dropdown
                     onChange={(e) => {
                       accountBookData[key].category = e
-
-                      //memo, price 초기화
-                      accountBookData[key].memo = ''
-                      accountBookData[key].price = 0
-
                       setAccountBook && setAccountBook({ ...accountBookData })
                     }}
                     options={category}
@@ -117,6 +115,19 @@ const AccountBookTable = ({
                     padding='0.75rem 0.75rem 0.75rem 2rem'
                   />
                   <KRWICon $viewMode={viewMode}>₩</KRWICon>
+                </td>
+                <td>
+                  <Dropdown
+                    onChange={(e) => {
+                      accountBookData[key].payment_type = e
+                      console.log(accountBookData[key])
+                      setAccountBook && setAccountBook({ ...accountBookData })
+                    }}
+                    options={paymentTypeOptions}
+                    defaultValue={accountBookData[key].payment_type}
+                    placeholder='지출 수단'
+                    viewMode={viewMode}
+                  />
                 </td>
                 <td>
                   <Input
@@ -149,20 +160,10 @@ const AccountBookTable = ({
             ).length === 0) && (
             <tr>
               <td>
-                <Dropdown
-                  onChange={() => {}}
-                  options={[{ label: '비어있음', value: '비어있음' }]}
-                  defaultValue='비어있음'
-                  placeholder='카테고리'
-                  viewMode={viewMode}
-                />
-              </td>
-              <td>
                 <Input
                   type='text'
                   value='비어있음'
                   onChange={() => {}}
-                  placeholder='금액'
                   textAlign='center'
                   viewMode={viewMode}
                 />
@@ -170,9 +171,26 @@ const AccountBookTable = ({
               <td>
                 <Input
                   type='text'
-                  onChange={() => {}}
                   value='비어있음'
-                  placeholder='메모'
+                  onChange={() => {}}
+                  textAlign='center'
+                  viewMode={viewMode}
+                />
+              </td>
+              <td>
+                <Input
+                  type='text'
+                  value='비어있음'
+                  onChange={() => {}}
+                  textAlign='center'
+                  viewMode={viewMode}
+                />
+              </td>
+              <td>
+                <Input
+                  type='text'
+                  value='비어있음'
+                  onChange={() => {}}
                   textAlign='center'
                   viewMode={viewMode}
                 />

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import styled, { css } from 'styled-components'
 import {
   formFieldStyles,
@@ -94,11 +94,6 @@ function Dropdown({
   const [isOpen, setIsOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
-  const defaultOption = useMemo(
-    () => options.find((option) => option.value === defaultValue),
-    [options, defaultValue]
-  )
-
   const toggleDropdown = () => {
     setIsOpen(!isOpen)
   }
@@ -130,7 +125,7 @@ function Dropdown({
     <DropdownContainer ref={dropdownRef}>
       <DropdownInput
         onClick={toggleDropdown}
-        value={defaultOption ? defaultOption.label : ''}
+        value={defaultValue}
         disabled={viewMode || disabled}
         placeholder={viewMode ? '' : placeholder}
         readOnly

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 import {
   formFieldStyles,
@@ -94,6 +94,12 @@ function Dropdown({
   const [isOpen, setIsOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
+  // defaultValue에 해당하는 option
+  const defaultOption = useMemo(
+    () => options.find((option) => option.value === defaultValue),
+    [options, defaultValue]
+  )
+
   const toggleDropdown = () => {
     setIsOpen(!isOpen)
   }
@@ -125,7 +131,7 @@ function Dropdown({
     <DropdownContainer ref={dropdownRef}>
       <DropdownInput
         onClick={toggleDropdown}
-        value={defaultValue}
+        value={defaultOption?.label || options[0].label}
         disabled={viewMode || disabled}
         placeholder={viewMode ? '' : placeholder}
         readOnly

--- a/src/components/common/Template.tsx
+++ b/src/components/common/Template.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 const Container = styled.div`
   width: 65%;
-  margin: 3rem auto 8rem;
+  margin: 3rem auto 10rem;
 `
 
 const Header = styled.header`

--- a/src/components/custom/Category.tsx
+++ b/src/components/custom/Category.tsx
@@ -129,7 +129,7 @@ const Category = ({
     <CategoryContainer>
       {categoriesArr.length !== 0
         ? categoriesArr.map((category, index) => (
-            <CategoryItem key={index}>
+            <CategoryItem key={`${category}-${index}`}>
               <span>{category}</span>
               {
                 // 카테고리가 1개이면 삭제 버튼 안보임

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -15,17 +15,16 @@ import Confirm from '../components/common/Confirm'
 import { Button, RedButton } from '../components/common/Button'
 import SidebarSetting from '../components/custom/SidebarSetting'
 import DailySetting from '../components/custom/DailySetting'
+import isEqual from 'lodash.isequal'
 
 const Setting = () => {
   const navigate = useNavigate()
-
   const { isOpen, onClose, onOpen } = useModal()
+  const { custom, isLoading } = useCustom()
 
   const [customData, setCustomData] = useState<Custom>(initialCustom)
-
   const [originData, setOriginData] = useState<Custom>(initialCustom)
-
-  const { custom, isLoading } = useCustom()
+  const [isSaveBtnDisabled, setSaveBtnDisabled] = useState(true)
 
   const { patchCustom, isPending } = usePatchCustom({
     onMutate: () => setCustom(customData),
@@ -42,6 +41,11 @@ const Setting = () => {
       setOriginData(deepCopy(custom))
     }
   }, [custom])
+
+  // originData와 customData 값이 다르면 저장 버튼 활성화
+  useEffect(() => {
+    setSaveBtnDisabled(isEqual(originData, customData))
+  }, [customData, originData])
 
   const handleCancle = () => {
     setCustomData(deepCopy(originData))
@@ -98,6 +102,7 @@ const Setting = () => {
         onCancle={handleCancle}
         onSave={patchCustom}
         onConfirm={onOpen}
+        disabled={isSaveBtnDisabled}
       />
     </>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export interface IAccountBook {
     price: number
     category: string
     is_income: boolean
+    payment_type: string
   }
 }
 


### PR DESCRIPTION
+ 카테고리 리스트 key 변경

+ 가계부 추가 시 사용자 커스텀 카테고리 중 첫번째 카테고리로 기본 세팅

+ 가계부 지출 수단(`payment_type`) 컬럼 추가

+ lodash.isequal 사용하여 설정 페이지 저장 버튼 조건부 활성화