### PR TITLE
refactor: 캘린더  일/토요일 컬러 값 추가

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -168,6 +168,9 @@ const Calendar = ({ isSidebarOpen, onToggle }: Props) => {
             const detail = data?.[dateIdx] as MonthDetail | null
             const selectedDate = `${monthYear.year}-${monthYear.month}-${dateIdx}`
 
+            const day = monthYear.startDate.set('date', date).get('d')
+            //요일 알아내기 - 0:일 ~ 6:토
+
             return (
               <DateBox
                 key={date}
@@ -176,6 +179,7 @@ const Calendar = ({ isSidebarOpen, onToggle }: Props) => {
                 detail={detail}
                 isCurrentMonth
                 isToday={isToday(dateIdx)}
+                day={day}
               />
             )
           })}

--- a/src/components/calendar/DateBox.tsx
+++ b/src/components/calendar/DateBox.tsx
@@ -38,7 +38,7 @@ const ContentContainer = styled.div`
   gap: 0.25rem;
 `
 
-const Date = styled.div<{ $isToday?: boolean }>`
+const Date = styled.div<{ $isToday?: boolean; $day?: number }>`
   text-align: center;
 
   div {
@@ -46,10 +46,17 @@ const Date = styled.div<{ $isToday?: boolean }>`
     justify-content: center;
     align-items: center;
 
-    ${({ $isToday, theme }) =>
+    background: ${({ $isToday, theme }) =>
+      $isToday ? theme.color.primary.main : 'transparent'};
+
+    color: ${({ $isToday, theme, $day }) =>
       $isToday
-        ? `background: ${theme.color.primary.main}; color: ${theme.color.white}`
-        : `background: transparent; color: inherit`};
+        ? theme.color.white
+        : $day === 0
+        ? theme.color.red.main
+        : $day === 6
+        ? theme.color.primary.main
+        : 'inherit'};
 
     width: 1rem;
     height: 1rem;
@@ -156,6 +163,8 @@ interface Props {
   detail?: MonthDetail | null
   isCurrentMonth?: boolean
   isToday?: boolean
+
+  day?: number
 }
 
 const DateBox = ({
@@ -164,6 +173,7 @@ const DateBox = ({
   detail,
   isCurrentMonth,
   isToday,
+  day,
 }: Props) => {
   const navigate = useNavigate()
   const { custom } = useCustom()
@@ -221,7 +231,7 @@ const DateBox = ({
         $isToday={isToday}
       >
         <ContentContainer>
-          <Date $isToday={isToday}>
+          <Date $isToday={isToday} $day={day}>
             <div>
               <span>{date}</span>
             </div>
@@ -254,7 +264,7 @@ const DateBox = ({
   return (
     <DateBoxContainer $isCurrentMonth={isCurrentMonth} $isToday={isToday}>
       <ContentContainer>
-        <Date $isToday={isToday}>
+        <Date $isToday={isToday} $day={day}>
           <div>{date}</div>
         </Date>
 


### PR DESCRIPTION
`monthYear.startDate` 에서 `set("date", date)`후 요일 얻어옴 => Databox props 추가
-> 0 : 일 ~ 6 : 토

`Date styled component` 에서 넘어온 day의 값이 `0 | 6`일 때 컬러가 `메인 | 레드`로 변경