### PR TITLE
style: 사이드바 월별 예상 지출 사용 유무에 따른 height 조정

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -94,7 +94,7 @@ const DOWCell = styled.div`
 `
 
 const DateGrid = styled.div<{ $weeksInMonth: number }>`
-  height: calc(100vh - 140px);
+  height: calc(100vh - 145px);
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   grid-template-rows: ${({ $weeksInMonth }) => `repeat(${$weeksInMonth}, 1fr)`};

--- a/src/components/sidebar/FixedExpense.tsx
+++ b/src/components/sidebar/FixedExpense.tsx
@@ -11,7 +11,7 @@ import FixedExpenseModal from './FixedExpenseModal'
 import { GrayBorderButton } from '../common/Button'
 import * as S from './Sidebar.styled'
 
-const Table = styled.table`
+const Table = styled.table<{ $enableExpectedLimit: boolean }>`
   width: 100%;
 
   border-spacing: 0;
@@ -31,9 +31,12 @@ const Table = styled.table`
 
   tbody {
     height: 100%;
-    max-height: ${({ theme }) =>
-      `calc(100vh - ${theme.layout.headerHeight} - 330px - 190px)`};
-
+    max-height: ${
+      ({ theme, $enableExpectedLimit }) =>
+        $enableExpectedLimit
+          ? `calc(100vh - ${theme.layout.headerHeight} - 215px - 325.5px)` // - (월별 예상 지출 + 합계)
+          : `calc(100vh - ${theme.layout.headerHeight} - 215px - 178.85px)` // - 합계
+    };
     overflow-y: scroll;
 
     font-size: ${({ theme }) => theme.fontSize.xs};
@@ -85,8 +88,7 @@ const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: ${({ theme }) =>
-    `calc(100vh - ${theme.layout.headerHeight} - 330px - 150px)`};
+  height: 100%;
 `
 
 const FixedTotalContainer = styled.div`
@@ -103,9 +105,14 @@ const FixedTotalContainer = styled.div`
 interface Props {
   fixedExpense: IFixedExpense
   category: string
+  enableExpectedLimit: boolean // 월별 예상 지출 설정 활성화 여부
 }
 
-const FixedExpense = ({ fixedExpense, category }: Props) => {
+const FixedExpense = ({
+  fixedExpense,
+  category,
+  enableExpectedLimit,
+}: Props) => {
   const { monthYear } = useMonthYearContext()
   const { onOpen, onClose, isOpen } = useModal()
   const [data, setData] = useState<IFixedExpense>({})
@@ -132,7 +139,7 @@ const FixedExpense = ({ fixedExpense, category }: Props) => {
   }
 
   return (
-    <S.Container $height>
+    <S.Container $height $enableExpectedLimit={enableExpectedLimit}>
       <S.TitleContainer>
         <span>고정 지출</span>
         <GrayBorderButton
@@ -144,7 +151,7 @@ const FixedExpense = ({ fixedExpense, category }: Props) => {
       </S.TitleContainer>
 
       <ContentContainer>
-        <Table>
+        <Table $enableExpectedLimit={enableExpectedLimit}>
           <thead>
             <tr>
               <th>지출일</th>

--- a/src/components/sidebar/Sidebar.styled.ts
+++ b/src/components/sidebar/Sidebar.styled.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 export const Container = styled.div<{
   $isBackground?: boolean
   $height?: boolean
+  $enableExpectedLimit?: boolean
 }>`
   padding: 1.5rem;
 
@@ -13,9 +14,12 @@ export const Container = styled.div<{
   background: ${({ theme, $isBackground }) =>
     $isBackground ? theme.color.gray0 : ''};
 
-  ${({ $height, theme }) =>
+  height: ${({ $height }) => ($height ? '100%' : '')};
+  max-height: ${({ $height, theme, $enableExpectedLimit }) =>
     $height
-      ? `height: calc(100vh - ${theme.layout.headerHeight} - 330px)`
+      ? $enableExpectedLimit
+        ? `calc(100vh - ${theme.layout.headerHeight} - 325.5px)` // - (월별 예상 지출 + 합계)
+        : `calc(100vh - ${theme.layout.headerHeight} - 178.85px)` // - 합계
       : ``};
 `
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -10,8 +10,6 @@ const Container = styled.section`
 
   width: 300px;
   background-color: ${({ theme }) => theme.color.white2};
-
-  height: calc(100vh - 70px);
 `
 
 const Title = styled.p`
@@ -37,9 +35,10 @@ const Sidebar = () => {
       <FixedExpense
         fixedExpense={custom.fixed_expense}
         category={custom.category.expense}
+        enableExpectedLimit={custom.expected_limit.is_possible}
       />
       <SubContainer>
-        <ExpectedLimit expectedLimit={custom.expected_limit} />
+        <ExpectedLimit expectedLimit={custom!.expected_limit} />
         <MonthlyFinancialOverview />
       </SubContainer>
     </Container>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,8 +6,9 @@ import { useMonthYearContext } from '../components/context/MonthYearContext'
 import Sidebar from '../components/sidebar/Sidebar'
 import useCustom from '../hooks/custom/useCustom'
 
-const Container = styled.div`
+const Container = styled.main`
   display: flex;
+  height: ${({ theme }) => `calc(100vh - ${theme.layout.headerHeight})`};
 `
 
 const Home = () => {
@@ -22,12 +23,10 @@ const Home = () => {
   if (calendarLoading || customLoading) return <LoadingSpinner />
 
   return (
-    <main>
-      <Container>
-        <Calendar isSidebarOpen={isSidebarOpen} onToggle={toggleSidebar} />
-        {isSidebarOpen && <Sidebar />}
-      </Container>
-    </main>
+    <Container>
+      <Calendar isSidebarOpen={isSidebarOpen} onToggle={toggleSidebar} />
+      {isSidebarOpen && <Sidebar />}
+    </Container>
   )
 }
 


### PR DESCRIPTION
+ home 페이지 전체 height, 캘린더 height 스크롤 생기지 않도록 수정

+ 사이드바 및 고정지출 테이블 월별 예상 지출 사용 유무에 따른 height 조정