### PR TITLE
fix: 모바일 섹션 toggle 상태 초기화

### DIFF
--- a/src/components/common/MobileSection.tsx
+++ b/src/components/common/MobileSection.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 
 import ChevronUp from '../../assets/icons/chevronUp.svg'
 import ChevronDown from '../../assets/icons/chevronDown.svg'
-import theme from '../../assets/css/theme'
 
 interface SectionProps {
   title?: string
@@ -14,9 +13,11 @@ interface SectionProps {
 
 const Container = styled.section`
   width: 100%;
+  border: none;
 
   @media screen and (max-width: 780px) {
     padding: 1.5rem;
+    border: 1px solid ${({ theme }) => theme.color.gray0};
   }
 
   h5 {
@@ -33,6 +34,10 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  @media (min-width: 780px) {
+    display: none;
+  }
 `
 
 const Button = styled.div`
@@ -40,11 +45,15 @@ const Button = styled.div`
     width: 20px;
     cursor: pointer;
   }
+
+  @media (min-width: 780px) {
+    display: none;
+  }
 `
 
 const MobileSection = ({ title, children }: SectionProps) => {
   const [toggle, setToggle] = useState(
-    Boolean(localStorage.getItem(`${title}_toggle`) ?? 'true')
+    localStorage.getItem(`${title}_toggle`) === 'true'
   )
 
   return (
@@ -54,11 +63,11 @@ const MobileSection = ({ title, children }: SectionProps) => {
           <h5>{title}</h5>
           <Button
             onClick={() => {
-              console.log(typeof toggle)
-
-              setToggle(!toggle)
-              localStorage.setItem(`${title}_toggle`, String(!toggle))
-              console.log(localStorage.getItem(`${title}_toggle`))
+              setToggle((prevToggle) => {
+                const newToggle = !prevToggle
+                localStorage.setItem(`${title}_toggle`, String(newToggle))
+                return newToggle
+              })
             }}
           >
             <img src={toggle ? ChevronUp : ChevronDown} alt='' />
@@ -66,7 +75,7 @@ const MobileSection = ({ title, children }: SectionProps) => {
         </Header>
       )}
 
-      {toggle && children}
+      {(!title || toggle) && children}
     </Container>
   )
 }


### PR DESCRIPTION
+ desktop에서 사용하지 않는 컴포넌트 `display: none` 처리
+ toggle state 초기화 수정
  
  ```jsx
  const [toggle, setToggle] = useState(
      Boolean(localStorage.getItem(`${title}_toggle`) ?? 'true')
  )
  ```
  
  여기에서 `localStorage.getItem(${title}_toggle)`는 문자열을 반환하며, `Boolean` 함수를 사용하여 불리언으로 변환합니다. 그러나 `'false'`라는 값이 저장되어 있을 때, Boolean 함수는 `true`를 반환하기 때문에 현재 toggle 상태 값은 항상 `true`가 될 수 밖에 없습니다.
  
  버튼 onClick 이벤트에서 `setToggle(!toggle)`에서 toggle 상태를 반전시켜서 사용하고 있기 때문에 토글이 되는 것처럼 보이지만, 새로고침 시 localStorage에 `false`가 저장되어 있어도 toggle은 항상 true 값을 갖기 때문에 children이 보이는걸 확인 할 수 있습니다.
  
  ```jsx
  const [toggle, setToggle] = useState(
      localStorage.getItem(`${title}_toggle`) === 'true'
  )
  ```
  
  위와 같이 수정하면 `localStorage`에서 가져온 값이 문자열 `'true'`와 일치하는지를 확인하므로 불리언 변환이 제대로 작동합니다.