### PR TITLE
fix: mobileSection desktop setting

### DIFF
--- a/src/components/common/MobileSection.tsx
+++ b/src/components/common/MobileSection.tsx
@@ -31,12 +31,12 @@ const Container = styled.section`
   }
 `
 const Header = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  display: none;
 
-  @media (min-width: 780px) {
-    display: none;
+  @media (max-width: 780px) {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 `
 
@@ -45,9 +45,18 @@ const Button = styled.div`
     width: 20px;
     cursor: pointer;
   }
+  display: none;
 
-  @media (min-width: 780px) {
-    display: none;
+  @media (max-width: 780px) {
+    display: block;
+  }
+`
+
+const ChildrenContainer = styled.div<{ $isShow: boolean }>`
+  display: block;
+
+  @media screen and (max-width: 780px) {
+    display: ${({ $isShow }) => ($isShow ? 'block' : 'none')};
   }
 `
 
@@ -75,7 +84,9 @@ const MobileSection = ({ title, children }: SectionProps) => {
         </Header>
       )}
 
-      {(!title || toggle) && children}
+      <ChildrenContainer $isShow={toggle || !title}>
+        {children}
+      </ChildrenContainer>
     </Container>
   )
 }


### PR DESCRIPTION

<img width="490" alt="image" src="https://github.com/wjdgml3092/harumoa/assets/59546994/21f41e73-1f90-450a-83e9-c65369b22510">
<img width="427" alt="image" src="https://github.com/wjdgml3092/harumoa/assets/59546994/9af016e3-750e-476e-b39a-c7f95c3f1b2a">


desktop에서 children이 보이지 않아, props로 받은 children을 div로 감싸서 toggle, title값을 boolean으로 줘서 데스크탑에서는 무조건 보이고, 모바일에서는 전달받은 props 값으로 none처리했습니다. 