### PR TITLE
feat: mobile sidebar 컴포넌트 정의

### DIFF
--- a/src/components/common/MobileSection.tsx
+++ b/src/components/common/MobileSection.tsx
@@ -12,12 +12,11 @@ interface SectionProps {
 }
 
 const Container = styled.section`
-  width: 100%;
   border: none;
 
   @media screen and (max-width: 780px) {
     padding: 1.5rem;
-    border: 1px solid ${({ theme }) => theme.color.gray0};
+    border-bottom: 1px solid ${({ theme }) => theme.color.gray0};
   }
 
   h5 {
@@ -65,20 +64,20 @@ const MobileSection = ({ title, children }: SectionProps) => {
     localStorage.getItem(`${title}_toggle`) === 'true'
   )
 
+  const handleClick = () => {
+    setToggle((prevToggle) => {
+      const newToggle = !prevToggle
+      localStorage.setItem(`${title}_toggle`, String(newToggle))
+      return newToggle
+    })
+  }
+
   return (
     <Container>
       {title && (
-        <Header>
+        <Header onClick={handleClick}>
           <h5>{title}</h5>
-          <Button
-            onClick={() => {
-              setToggle((prevToggle) => {
-                const newToggle = !prevToggle
-                localStorage.setItem(`${title}_toggle`, String(newToggle))
-                return newToggle
-              })
-            }}
-          >
+          <Button onClick={handleClick}>
             <img src={toggle ? ChevronUp : ChevronDown} alt='' />
           </Button>
         </Header>

--- a/src/components/sidebar/MobileSidebar.tsx
+++ b/src/components/sidebar/MobileSidebar.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components'
+import { initialCustom } from '../../constants/config'
+import useCustom from '../../hooks/custom/useCustom'
+import MobileSection from '../common/MobileSection'
+import ExpectedLimit from './ExpectedLimit'
+import FixedExpense from './FixedExpense'
+
+const Container = styled.div`
+  display: none;
+
+  @media screen and (max-width: 780px) {
+    display: block;
+  }
+`
+
+const MobileSidebar = () => {
+  const { custom } = useCustom()
+  const expenseCategory =
+    localStorage.getItem('category_expense') ?? initialCustom.category.expense
+
+  return (
+    <Container>
+      <MobileSection title='월별 예상 지출'>
+        <ExpectedLimit
+          expectedLimit={custom?.expected_limit ?? initialCustom.expected_limit}
+        />
+      </MobileSection>
+
+      <MobileSection title='고정 지출'>
+        <FixedExpense
+          fixedExpense={custom?.fixed_expense ?? initialCustom.fixed_expense}
+          category={expenseCategory}
+          enableExpectedLimit={
+            custom?.expected_limit.is_possible ??
+            initialCustom.expected_limit.is_possible
+          }
+        />
+      </MobileSection>
+    </Container>
+  )
+}
+
+export default MobileSidebar

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,9 +6,11 @@ import { useMonthYearContext } from '../components/context/MonthYearContext'
 import Sidebar from '../components/sidebar/Sidebar'
 import useCustom from '../hooks/custom/useCustom'
 import MobileSection from '../components/common/MobileSection'
+import MobileSidebar from '../components/sidebar/MobileSidebar'
 
 const Container = styled.main`
   display: flex;
+  flex-direction: column;
   height: ${({ theme }) => `calc(100vh - ${theme.layout.headerHeight})`};
 `
 
@@ -34,6 +36,8 @@ const Home = () => {
           {isSidebarOpen && <Sidebar />}
         </DesktopContainer>
       </MobileSection>
+
+      <MobileSidebar />
     </Container>
   )
 }


### PR DESCRIPTION
데스크탑 사이드바에 고정 지출, 월별 예상 지출 부분이 모바일 홈으로 나오게 됨.
고정 지출, 월별 예상 지출을 한 파일에서 import하고 모바일에서 `display: block`으로 처리하고 홈에서 한 파일만 `import` 함
`useCustom`도 한번만 불러도 됨!