### PR TITLE
refactor: 고정지출 추가 시 편집모드 리팩토링

### DIFF
--- a/src/components/sidebar/MobileFixedExpenseItem.tsx
+++ b/src/components/sidebar/MobileFixedExpenseItem.tsx
@@ -28,7 +28,7 @@ const Header = styled.header`
 
   position: sticky;
   top: 0;
-  background-color: white;c
+  background-color: white;
   z-index: 1;
 `
 
@@ -225,7 +225,7 @@ const MobileFixedExpenseItem = ({
           {isEdit ? (
             <>
               <Button
-                value='되돌리기'
+                value={viewMode ? '되돌리기' : '초기화'}
                 onClick={() => setNewData(deepCopy(originData))}
                 disabled={isEqual(originData, newData)}
               />

--- a/src/components/sidebar/MobileSidebar.tsx
+++ b/src/components/sidebar/MobileSidebar.tsx
@@ -9,6 +9,7 @@ import MobileSection from '../common/MobileSection'
 import ExpectedLimit from './ExpectedLimit'
 import FixedExpense from './FixedExpense'
 import MobileFixedExpenseItem from './MobileFixedExpenseItem'
+import { IFixedExpense } from '../../types'
 
 const Container = styled.div`
   display: none;
@@ -43,8 +44,12 @@ const MobileSidebar = () => {
   const { is_possible: expectedLimitisPossible } = expectedLimitProps
 
   const [newId, setNewId] = useState<string>('')
-  const [newFixedExpense, setNewFixedExpense] = useState({})
-  const { BottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet()
+  const [newFixedExpense, setNewFixedExpense] = useState<IFixedExpense>({})
+
+  const { BottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet(
+    () => setNewId('')
+  )
+
   const category =
     localStorage.getItem('category_expense') ?? initialCustom.category.expense
 
@@ -112,11 +117,11 @@ const MobileSidebar = () => {
             data={newFixedExpense}
             setData={setNewFixedExpense}
             category={category}
-            onClose={() => {
-              closeBottomSheet()
-              setNewId('')
-            }}
-            viewMode={false}
+            onClose={closeBottomSheet}
+            viewMode={
+              Object.keys(newFixedExpense).length !== 0 &&
+              newFixedExpense[newId].price !== 0
+            }
           />
         </BottomSheet>
       )}

--- a/src/hooks/useBottomSheet.tsx
+++ b/src/hooks/useBottomSheet.tsx
@@ -27,7 +27,7 @@ const BottomSheetWrapper = styled.div<{ $isOpen: boolean }>`
   z-index: 2;
 `
 
-const useBottomSheet = () => {
+const useBottomSheet = (onClose?: () => void) => {
   const [isOpen, setIsOpen] = useState(false)
 
   const openBottomSheet = useCallback(() => {
@@ -35,6 +35,7 @@ const useBottomSheet = () => {
   }, [])
 
   const closeBottomSheet = useCallback(() => {
+    onClose && onClose()
     setIsOpen(false)
   }, [])
 


### PR DESCRIPTION
모바일 고정지출 추가 시 추가 후 편집모드가 `true`로 false로 안바뀌는 상황발생

- useBottomSheet hook 파일에서 함수 파라미터 `onClose` 추가 => newId 초기화
- `MobileFixedExpenseItem.tsx` props 주는 viewMode 조건 추가
- 추가 시 되돌리기 -> 초기화로 텍스트 변경